### PR TITLE
Require sexplib < v0.9.0

### DIFF
--- a/opam
+++ b/opam
@@ -17,6 +17,7 @@ depends: [
   "omake"
   "ocamlfind" {>= "1.5.1"}
   "core_kernel"
+  "sexplib" {< "v0.9.0"}
   "extunix"
   "ocplib-endian" {>= "0.7"}
   "res"


### PR DESCRIPTION
Otherwise, building fails on OCaml 4.03 and 4.04 with:

    # File "./make_includes.ml", line 1:
    # Error: Reference to undefined global `Ephemeron'
    # *** omake: targets were not rebuilt because of errors:
    #    src/compiler/includes.ml
    #       depends on: src/compiler/make_includes.ml
    #       depends on: src/runtime/common-inc.ml
    #       depends on: src/runtime/reader-inc.ml
    #       depends on: src/runtime/builder-inc.ml

See also: #16