### PR TITLE
Replace defun files with flambda inlining

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -368,9 +368,9 @@ You will need to
 http://kentonv.github.io/capnproto/install.html[install the Cap\'n Proto compiler].
 Once the Cap\'n Proto compiler and capnp-ocaml are both installed, you should be
 able to use `capnp compile -o ocaml yourSchemaFile.capnp` in order to generate
-`yourSchemaFile.mli` and `yourSchemaFile.ml` (as well as `yourSchemaFile_defun.ml`,
-referenced below).  These modules will link against OCaml packages
-`core_kernel`, `extunix`, `uint`, `ocplib-endian`, `res`, and of course `capnp`.
+`yourSchemaFile.mli` and `yourSchemaFile.ml`.  These modules will link against
+OCaml packages `core_kernel`, `extunix`, `uint`, `ocplib-endian`, `res`, and of
+course `capnp`.
 
 Instantiating the Modules
 -------------------------
@@ -395,28 +395,21 @@ let root_struct = YSF.Builder.Foo.init_root () in
 (* ... *)
 --------------------------------------------------------------------------------
 
-Defunctorized Module Instantiation
-----------------------------------
+Performance
+-----------
 For certain applications, the overhead associated with OCaml functors may
-be problematic. The functors may be eliminated by directly including the
-generated accessor code, at the cost of increased compile time. The code
-generator plugin emits `*_defun.ml` files intended for this use case:
+be problematic. The functors may be eliminated by compiling with an flambda
+build of the OCaml compiler (e.g. `opam switch 4.04.1+flambda`) and using the
+`@inlined` annotation, like this:
+
 [source,ocaml]
 --------------------------------------------------------------------------------
-module YSF :
-  YourSchemaFile.S with type 'cap message_t = 'cap Capnp.BytesMessage.Message.t
-= struct
-  module MessageWrapper = Capnp.BytesMessage
-  INCLUDE "yourSchemaFile_defun.ml"
-end
-
-let root_struct = YSF.Builder.Foo.init_root () in
-(* ... *)
+module YSF = YourSchemaFile.Make[@inlined](Capnp.BytesMessage)
 --------------------------------------------------------------------------------
 
-The `INCLUDE` directive is a standard `camlp4` syntax extension provided by
-the `camlp4.macro` package.
-
+You can use the `ocamlopt -inlining-report` option to check that the code has
+been inlined. It may also be a good idea to compile with `-O3` if you care
+about speed.
 
 I Need to See an Example
 ------------------------

--- a/opam
+++ b/opam
@@ -17,6 +17,7 @@ depends: [
   "omake"
   "ocamlfind" {>= "1.5.1"}
   "core_kernel"
+  "sexplib" {< "v0.9.0"}
   "extunix"
   "ocplib-endian" {>= "0.7"}
   "res"

--- a/src/benchmark/OMakefile
+++ b/src/benchmark/OMakefile
@@ -1,19 +1,8 @@
+OCAMLOPTFLAGS += -inlining-report -O3
 OCAMLINCLUDES += ../runtime
 OCAML_LIBS += ../runtime/libcapnp
 OCAML_CLIBS = libfastrand
 OCAMLPACKS += core
-
-Camlp4o(module) =
-    section
-        OCAMLFINDFLAGS += -syntax camlp4o
-        $(module).cmi:
-        $(module).cmo:
-        $(module).o:
-        $(module).cmx:
-
-Camlp4o(capnpCarsales)
-Camlp4o(capnpCatrank)
-Camlp4o(capnpEval)
 
 GENERATED = \
   c2b2b.mli \

--- a/src/benchmark/capnpCarsales.ml
+++ b/src/benchmark/capnpCarsales.ml
@@ -1,10 +1,5 @@
 
-module CS :
-  Carsales.S with type 'cap message_t = 'cap Capnp.BytesMessage.Message.t
-= struct
-  module MessageWrapper = Capnp.BytesMessage
-  INCLUDE "carsales_defun.ml"
-end
+module CS = Carsales.Make(Capnp.BytesMessage)
 
 module TestCase = struct
   type request_reader_t   = CS.Reader.ParkingLot.t

--- a/src/benchmark/capnpCarsales.ml
+++ b/src/benchmark/capnpCarsales.ml
@@ -1,5 +1,5 @@
 
-module CS = Carsales.Make(Capnp.BytesMessage)
+module CS = Carsales.Make[@inlined](Capnp.BytesMessage)
 
 module TestCase = struct
   type request_reader_t   = CS.Reader.ParkingLot.t

--- a/src/benchmark/capnpCatrank.ml
+++ b/src/benchmark/capnpCatrank.ml
@@ -1,7 +1,7 @@
 
 module CamlBytes = Bytes
 
-module CR = Catrank.Make(Capnp.BytesMessage)
+module CR = Catrank.Make[@inlined](Capnp.BytesMessage)
 
 open Core_kernel.Std
 

--- a/src/benchmark/capnpCatrank.ml
+++ b/src/benchmark/capnpCatrank.ml
@@ -1,12 +1,7 @@
 
 module CamlBytes = Bytes
 
-module CR :
-  Catrank.S with type 'cap message_t = 'cap Capnp.BytesMessage.Message.t
-= struct
-  module MessageWrapper = Capnp.BytesMessage
-  INCLUDE "catrank_defun.ml"
-end
+module CR = Catrank.Make(Capnp.BytesMessage)
 
 open Core_kernel.Std
 

--- a/src/benchmark/capnpEval.ml
+++ b/src/benchmark/capnpEval.ml
@@ -1,5 +1,5 @@
 
-module E = Eval.Make(Capnp.BytesMessage)
+module E = Eval.Make[@inlined](Capnp.BytesMessage)
 
 open Core_kernel.Std
 

--- a/src/benchmark/capnpEval.ml
+++ b/src/benchmark/capnpEval.ml
@@ -1,10 +1,5 @@
 
-module E :
-  Eval.S with type 'cap message_t = 'cap Capnp.BytesMessage.Message.t
-= struct
-  module MessageWrapper = Capnp.BytesMessage
-  INCLUDE "eval_defun.ml"
-end
+module E = Eval.Make(Capnp.BytesMessage)
 
 open Core_kernel.Std
 

--- a/src/benchmark/test.py
+++ b/src/benchmark/test.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+import subprocess, os, csv, time
+
+#subprocess.check_call(["omake", "clean", "bench-clean"])
+subprocess.check_call(["omake", "carsales", "catrank", "eval"])
+
+switch = subprocess.check_output(["opam", "sw", "show"]).strip()
+
+print "Current switich: %s" % switch
+
+baseline = {
+        ('./carsales', 'pipe', 'none'): 67433620.95888832,
+        ('./catrank', 'pipe', 'packed'): 65141369.52621308,
+        ('./eval', 'pipe', 'none'): 61535819.20844552,
+}
+
+results = {}
+
+def run(cmd, base_iters, scale):
+    key = '-'.join(([cmd[0][2:]] + cmd[1:]))
+    base = baseline[tuple(cmd)]
+    iters = int(base_iters * scale)
+    cmd = cmd + [str(iters)]
+    t0 = time.time()
+    throughput = int(subprocess.check_output(cmd))
+    t1 = time.time()
+    t = t1 - t0
+    rate = throughput / t
+    frac = 100 * rate / base
+    cmd = " ".join(cmd)
+    print "%6.2f%% of baseline: %3.1f x %s" % (frac, scale, key)
+    if scale not in results: results[scale] = {}
+    results[scale][key] = frac
+
+scale = 1.0
+while scale < 10:
+    run(["./carsales", "pipe", "none"], 5000, scale)
+    run(["./catrank", "pipe", "packed"], 500, scale)
+    run(["./eval", "pipe", "none"], 50000, scale)
+    scale *= 1.5
+
+series = sorted(results[1.0].keys())
+scales = sorted(results.keys())
+
+with open('results-%s.csv' % switch, 'wb') as csvfile:
+    writer = csv.writer(csvfile)
+    writer.writerow(["Scale"] + series)
+    for scale in scales:
+        res = [results[scale][k] for k in series]
+        writer.writerow([scale] + res)

--- a/src/benchmark/test.py
+++ b/src/benchmark/test.py
@@ -6,7 +6,7 @@ subprocess.check_call(["omake", "carsales", "catrank", "eval"])
 
 switch = subprocess.check_output(["opam", "sw", "show"]).strip()
 
-print "Current switich: %s" % switch
+print "Current switch: %s" % switch
 
 baseline = {
         ('./carsales', 'pipe', 'none'): 67433620.95888832,

--- a/src/compiler/genModules.ml
+++ b/src/compiler/genModules.ml
@@ -1229,6 +1229,10 @@ let generate_one_field_accessors ~context ~node_id ~scope
             ] in
             let setters = [
               "let " ^ field_name ^ "_set x v =";
+              sprintf "  BA_.set_pointer %sx %u (Some v)"
+                discr_str
+                field_ofs;
+              "let " ^ field_name ^ "_set_reader x v =";
               sprintf "  BA_.set_pointer %sx %u v"
                 discr_str
                 field_ofs;

--- a/src/compiler/genSignatures.ml
+++ b/src/compiler/genSignatures.ml
@@ -157,6 +157,10 @@ let generate_one_field_accessors ~context ~scope ~mode field
               field_name
               (GenCommon.type_name ~context ~mode ~scope_mode:mode scope tp)
               (GenCommon.type_name ~context ~mode ~scope_mode:mode scope tp);
+            sprintf "val %s_set_reader : t -> %s -> %s"
+              field_name
+              (GenCommon.type_name ~context ~mode:Mode.Reader ~scope_mode:mode scope tp)
+              (GenCommon.type_name ~context ~mode ~scope_mode:mode scope tp);
             sprintf "val %s_set_interface : t -> Uint32.t option -> unit"
               field_name ];
         ]

--- a/src/compiler/generate.ml
+++ b/src/compiler/generate.ml
@@ -151,10 +151,6 @@ let mli_filename filename =
   let module_name = GenCommon.make_legal_module_name filename in
   String.uncapitalize (module_name ^ ".mli")
 
-let ml_defun_filename filename =
-  let module_name = GenCommon.make_legal_module_name filename in
-  String.uncapitalize (module_name ^ "_defun.ml")
-
 
 let string_of_lines lines =
   (String.concat ~sep:"\n" lines) ^ "\n"
@@ -270,28 +266,16 @@ let compile
         mod_shared_content @
         mod_functor_footer)
     in
-    let mod_defun_content =
-      string_of_lines ( [
-        "  module CamlBytes = Bytes";
-        "  type ro = Capnp.Message.ro";
-        "  type rw = Capnp.Message.rw";
-      ] @
-      mod_shared_content)
-    in
     let () = Out_channel.with_file (mli_filename requested_filename)
         ~f:(fun chan -> Out_channel.output_string chan sig_file_content)
     in
     let () = Out_channel.with_file (ml_filename requested_filename)
         ~f:(fun chan -> Out_channel.output_string chan mod_file_content)
     in
-    let () = Out_channel.with_file (ml_defun_filename requested_filename)
-        ~f:(fun chan -> Out_channel.output_string chan mod_defun_content)
-    in
-    let () = Printf.printf "%s --> %s %s %s\n"
+    let () = Printf.printf "%s --> %s %s\n"
         requested_filename
         (mli_filename requested_filename)
         (ml_filename requested_filename)
-        (ml_defun_filename requested_filename)
     in
     ())
 

--- a/src/compiler/generate.ml
+++ b/src/compiler/generate.ml
@@ -138,7 +138,7 @@ let mod_footer = [
 ]
 
 let mod_functor_footer = [
-  "end";
+  "end [@@inline]";
   "";
 ]
 

--- a/src/runtime/builder-inc.ml
+++ b/src/runtime/builder-inc.ml
@@ -1068,7 +1068,7 @@ let set_pointer
     ?(discr : Discr.t option)
     (struct_storage : rw NM.StructStorage.t)
     (pointer_word : int)
-    (value : 'cap NM.Slice.t)
+    (value : 'cap NM.Slice.t option)
   : rw NM.Slice.t =
   let pointers = struct_storage.NM.StructStorage.pointers in
   let num_pointers = pointers.NM.Slice.len / sizeof_uint64 in
@@ -1081,7 +1081,12 @@ let set_pointer
     NM.Slice.len   = sizeof_uint64;
   } in
   let () = set_opt_discriminant struct_storage.NM.StructStorage.data discr in
-  let () = BOps.deep_copy_pointer ~src:value ~dest:pointer_bytes in
+  let () = BOps.deep_zero_pointer pointer_bytes in
+  let () =
+    match value with
+    | Some value -> BOps.deep_copy_pointer ~src:value ~dest:pointer_bytes
+    | None -> ()
+  in
   pointer_bytes
 
 let set_interface
@@ -1101,6 +1106,7 @@ let set_interface
     NM.Slice.len   = sizeof_uint64;
   } in
   let () = set_opt_discriminant struct_storage.NM.StructStorage.data discr in
+  let () = BOps.deep_zero_pointer pointer_bytes in
   match value with
   | Some index ->
       NM.Slice.set_int64 pointer_bytes 0

--- a/src/tests/testEncoding.ml
+++ b/src/tests/testEncoding.ml
@@ -1634,7 +1634,10 @@ let test_any_pointers ctx =
   let rroot = T.Reader.TestAnyPointer.of_builder root in
   let rptr = T.Reader.TestAnyPointer.any_pointer_field_get rroot in
   let rchild = T.Reader.TestSturdyRefHostId.of_pointer rptr in
-  assert_equal ~printer:(fun f -> f) (T.Reader.TestSturdyRefHostId.host_get rchild) "test-host";
+  assert_equal ~printer:(fun f -> f) "test-host" (T.Reader.TestSturdyRefHostId.host_get rchild);
+  (* Test zeroing out *)
+  T.Builder.TestAnyPointer.any_pointer_field_set_reader root None;
+  assert_equal ~printer:(fun f -> f) "" (T.Reader.TestSturdyRefHostId.host_get rchild);
   (* Interfaces *)
   T.Builder.TestAnyPointer.any_pointer_field_set_interface root (Some (Uint32.of_int 42));
   let iface = T.Reader.TestAnyPointer.any_pointer_field_get_interface rroot in


### PR DESCRIPTION
Fixes #7.

I've added the benchmark script I used to test this too. Switching from 4.04.1 to 4.04.1+flambda doesn't have any noticable effect by itself when using the `_defun` files.

After switching to the functor versions, carsales drops to about 85% of the `_defun` version's performance. The other two tests seem less affected. Catrank got 99% and eval got 97% of their baselines (within the margin of error).

After adding `@inline` annotations the performance returned to the defun level.

After also turning on `-O3`, carsales ran at 130% of the baseline speed, catrank at 105% and eval at 118%.

Note: this PR is on top of #18 and #19, which haven't been merged yet, so the actual diff is smaller than it appears.