### PR TITLE
Share the definitions of reader_t and builder_t

### DIFF
--- a/src/compiler/defaults.ml
+++ b/src/compiler/defaults.ml
@@ -64,13 +64,15 @@ module ListStorageType = Capnp.Runtime.ListStorageType
 
 let sizeof_uint64 = 8
 
+type abstract
+
 type t = {
   (* Message storage. *)
   message : Capnp.Message.rw M.Message.t;
 
   (* Array of structs which have been stored in the message, along with
      their unique identifiers. *)
-  structs : (string * Capnp.Message.rw M.StructStorage.t) Res.Array.t;
+  structs : (string * (Capnp.Message.rw, abstract) M.StructStorage.t) Res.Array.t;
 
   (* Array of lists which have been stored in the message, along with
      their unique identifiers. *)

--- a/src/compiler/defaults.ml
+++ b/src/compiler/defaults.ml
@@ -178,28 +178,28 @@ let emit_instantiate_builder_structs struct_array : string list =
       "  let data_segment_id = " ^
         (Int.to_string struct_storage.data.M.Slice.segment_id) ^ " in";
       "  let pointers_segment_id = " ^
-        (Int.to_string struct_storage.pointers.M.Slice.segment_id) ^ " in {";
-      "  DefaultsMessage_.StructStorage.data = {";
-      "    DefaultsMessage_.Slice.msg = _builder_defaults_message;";
-      "    DefaultsMessage_.Slice.segment = DefaultsMessage_.Message.get_segment \
+        (Int.to_string struct_storage.pointers.M.Slice.segment_id) ^ " in";
+      "  DefaultsMessage_.StructStorage.v";
+      "    ~data:{";
+      "      DefaultsMessage_.Slice.msg = _builder_defaults_message;";
+      "      DefaultsMessage_.Slice.segment = DefaultsMessage_.Message.get_segment \
        _builder_defaults_message data_segment_id;";
-      "    DefaultsMessage_.Slice.segment_id = data_segment_id;";
-      "    DefaultsMessage_.Slice.start = " ^
+      "      DefaultsMessage_.Slice.segment_id = data_segment_id;";
+      "      DefaultsMessage_.Slice.start = " ^
         (Int.to_string struct_storage.data.M.Slice.start) ^ ";";
-      "    DefaultsMessage_.Slice.len = " ^
+      "      DefaultsMessage_.Slice.len = " ^
         (Int.to_string struct_storage.data.M.Slice.len) ^ ";";
-      "  };";
-      "  DefaultsMessage_.StructStorage.pointers = {";
-      "    DefaultsMessage_.Slice.msg = _builder_defaults_message;";
-      "    DefaultsMessage_.Slice.segment = DefaultsMessage_.Message.get_segment \
+      "    }";
+      "    ~pointers:{";
+      "      DefaultsMessage_.Slice.msg = _builder_defaults_message;";
+      "      DefaultsMessage_.Slice.segment = DefaultsMessage_.Message.get_segment \
        _builder_defaults_message pointers_segment_id;";
-      "    DefaultsMessage_.Slice.segment_id = pointers_segment_id;";
-      "    DefaultsMessage_.Slice.start = " ^
+      "      DefaultsMessage_.Slice.segment_id = pointers_segment_id;";
+      "      DefaultsMessage_.Slice.start = " ^
         (Int.to_string struct_storage.pointers.M.Slice.start) ^ ";";
-      "    DefaultsMessage_.Slice.len = " ^
+      "      DefaultsMessage_.Slice.len = " ^
         (Int.to_string struct_storage.pointers.M.Slice.len) ^ ";";
-      "  };";
-      "}";
+      "    }";
       "";
     ] @ acc)
     struct_array

--- a/src/compiler/defaults.mli
+++ b/src/compiler/defaults.mli
@@ -43,7 +43,7 @@ val create : unit -> t
 (** [add_struct defaults ident s] adds a deep copy of struct [s] to the
     defaults message, making it accessible under the specified identifier. *)
 val add_struct : t -> ident_t ->
-  Capnp.Message.ro GenCommon.M.StructStorage.t -> unit
+  (Capnp.Message.ro, _) GenCommon.M.StructStorage.t -> unit
 
 (** [add_list defaults ident lst] adds a deep copy of list [lst] to the
     defaults message, making it accessible under the specified identifier. *)

--- a/src/compiler/genModules.ml
+++ b/src/compiler/genModules.ml
@@ -236,11 +236,11 @@ let rec generate_list_element_codecs ~context ~scope list_def =
   let make_terminal_codecs element_name = [
       "let codecs =";
       "  let decode slice =";
-      "    let struct_storage = RA_.pointers_struct slice in";
+      "    let struct_storage = BA_.pointers_struct slice in";
       "    BA_.get_" ^ element_name ^ "_list struct_storage 0";
       "  in";
       "  let encode v slice =";
-      "    let struct_storage = RA_.pointers_struct slice in";
+      "    let struct_storage = BA_.pointers_struct slice in";
       "    let _ = BA_.set_" ^ element_name ^ "_list struct_storage 0 v in ()";
       "  in";
       "  BA_.NC.ListCodecs.Pointer (decode, encode)";
@@ -723,7 +723,7 @@ let generate_one_field_accessors ~context ~node_id ~scope
   let (getters, setters) =
     begin match PS.Field.get field with
     | PS.Field.Group group ->
-        let getters = [ "let " ^ field_name ^ "_get x = x" ] in
+        let getters = [ sprintf "let %s_get x = %s.cast_struct x" field_name api_module ] in
         let setters =
           let clear_fields =
             apply_indent ~indent:"  "
@@ -750,7 +750,7 @@ let generate_one_field_accessors ~context ~node_id ~scope
             "  let () = ignore pointers in"; ] @
             set_discriminant @
             clear_fields @
-            [ "  x" ]
+            [ sprintf "  %s.cast_struct x" api_module ]
         in
         (getters, setters)
     | PS.Field.Slot slot ->
@@ -1578,7 +1578,11 @@ and generate_node
           (apply_indent ~indent:"  " body) @
           [ "end" ]
   | PS.Node.Const const_def -> [
-      "let " ^ (GenCommon.underscore_name node_name) ^ " =";
+      let typ =
+        PS.Node.Const.type_get const_def
+        |> GenCommon.type_name ~context ~mode:Mode.Reader ~scope_mode:mode scope
+      in
+      sprintf "let %s : %s =" (GenCommon.underscore_name node_name) typ
     ] @ (apply_indent ~indent:"  "
           (generate_constant ~context ~scope ~node ~node_name const_def))
   | PS.Node.Annotation _ ->

--- a/src/compiler/genModules.ml
+++ b/src/compiler/genModules.ml
@@ -170,13 +170,7 @@ let rec generate_list_element_decoder ~context ~scope list_def =
   let make_terminal_decoder element_name = [
       "let decoders = RA_.ListDecoders.Pointer (fun slice ->";
       (* Not super efficient, but this shouldn't be a hot path very often... *)
-      "  let struct_storage = {";
-      "    RA_.StructStorage.data = {";
-      "      slice with";
-      "      RA_.Slice.len = 0;";
-      "    };";
-      "    RA_.StructStorage.pointers = slice;";
-      "  } in";
+      "  let struct_storage = RA_.pointers_struct slice in";
       "  RA_.get_" ^ element_name ^ "_list (Some struct_storage) 0)";
       "in";
     ]
@@ -207,13 +201,7 @@ let rec generate_list_element_decoder ~context ~scope list_def =
         "let decoders = RA_.ListDecoders.Pointer (fun slice ->";
       ] @ inner_decoder_decl @ [
         (* Not super efficient, but this shouldn't be a hot path very often... *)
-        "  let struct_storage = {";
-        "    RA_.StructStorage.data = {";
-        "      slice with";
-        "      RA_.Slice.len = 0;";
-        "    };";
-        "    RA_.StructStorage.pointers = slice;";
-        "  } in";
+        "  let struct_storage = RA_.pointers_struct slice in";
         "  RA_.get_list decoders (Some struct_storage) 0)";
         "in";
       ]
@@ -228,13 +216,7 @@ let rec generate_list_element_decoder ~context ~scope list_def =
       ] @ enum_getters @ [
         "  RA_.ListDecoders.Pointer (fun slice ->";
         (* Not super efficient, but this shouldn't be a hot path very often... *)
-        "    let struct_storage = {";
-        "      RA_.StructStorage.data = {";
-        "        slice with";
-        "        RA_.Slice.len = 0;";
-        "      };";
-        "      RA_.StructStorage.pointers = slice;";
-        "    } in";
+        "    let struct_storage = RA_.pointers_struct slice in";
         "    get_enum_list (Some struct_storage) 0)";
         "in";
       ]
@@ -254,23 +236,11 @@ let rec generate_list_element_codecs ~context ~scope list_def =
   let make_terminal_codecs element_name = [
       "let codecs =";
       "  let decode slice =";
-      "    let struct_storage = {";
-      "      BA_.NM.StructStorage.data = {";
-      "        slice with";
-      "        BA_.NM.Slice.len = 0;";
-      "      };";
-      "      BA_.NM.StructStorage.pointers = slice;";
-      "    } in";
+      "    let struct_storage = RA_.pointers_struct slice in";
       "    BA_.get_" ^ element_name ^ "_list struct_storage 0";
       "  in";
       "  let encode v slice =";
-      "    let struct_storage = {";
-      "      BA_.NM.StructStorage.data = {";
-      "        slice with";
-      "        BA_.NM.Slice.len = 0;";
-      "      };";
-      "      BA_.NM.StructStorage.pointers = slice;";
-      "    } in";
+      "    let struct_storage = RA_.pointers_struct slice in";
       "    let _ = BA_.set_" ^ element_name ^ "_list struct_storage 0 v in ()";
       "  in";
       "  BA_.NC.ListCodecs.Pointer (decode, encode)";
@@ -308,25 +278,13 @@ let rec generate_list_element_codecs ~context ~scope list_def =
       in [
         "let codecs =";
         "  let decode slice =";
-        "    let struct_storage = {";
-        "      BA_.NM.StructStorage.data = {";
-        "        slice with";
-        "        BA_.NM.Slice.len = 0;";
-        "      };";
-        "      BA_.NM.StructStorage.pointers = slice;";
-        "    } in";
+        "    let struct_storage = BA_.pointers_struct slice in";
         sprintf "    BA_.get_struct_list \
                  ~data_words:%u ~pointer_words:%u struct_storage 0"
           data_words pointer_words;
         "  in";
         "  let encode v slice =";
-        "    let struct_storage = {";
-        "      BA_.NM.StructStorage.data = {";
-        "        slice with";
-        "        BA_.NM.Slice.len = 0;";
-        "      };";
-        "      BA_.NM.StructStorage.pointers = slice;";
-        "    } in";
+        "    let struct_storage = BA_.pointers_struct slice in";
         sprintf "    let _ = BA_.set_struct_list \
                  ~data_words:%u ~pointer_words:%u struct_storage 0 v in ()"
           data_words pointer_words;
@@ -341,23 +299,11 @@ let rec generate_list_element_codecs ~context ~scope list_def =
       in [
         "let codecs ="; ] @ inner_codecs_decl @ [
         "  let decode slice =";
-        "    let struct_storage = {";
-        "      BA_.NM.StructStorage.data = {";
-        "        slice with";
-        "        BA_.NM.Slice.len = 0;";
-        "      };";
-        "      BA_.NM.StructStorage.pointers = slice;";
-        "    } in";
+        "    let struct_storage = BA_.pointers_struct slice in";
         "    BA_.get_list ~codecs struct_storage 0";
         "  in";
         "  let encode v slice =";
-        "    let struct_storage = {";
-        "      BA_.NM.StructStorage.data = {";
-        "        slice with";
-        "        BA_.NM.Slice.len = 0;";
-        "      };";
-        "      BA_.NM.StructStorage.pointers = slice;";
-        "    } in";
+        "    let struct_storage = BA_.pointers_struct slice in";
         "    BA_.set_list ~codecs struct_storage 0 v";
         "  in";
         "  BA_.NC.ListCodecs.Pointer (decode, encode)";

--- a/src/compiler/generate.ml
+++ b/src/compiler/generate.ml
@@ -84,7 +84,9 @@ let functor_sig ~context = [
   "module Make (MessageWrapper : Capnp.MessageSig.S) :";
   "  (S with type 'cap message_t = 'cap MessageWrapper.Message.t";
   "    and type Reader.pointer_t = ro MessageWrapper.Slice.t option";
-  "    and type Builder.pointer_t = rw MessageWrapper.Slice.t"; ] @
+  "    and type Builder.pointer_t = rw MessageWrapper.Slice.t";
+  "    and type 'a reader_t = 'a MessageWrapper.StructStorage.reader_t";
+  "    and type 'a builder_t = 'a MessageWrapper.StructStorage.builder_t"; ] @
   (List.concat_map context.Context.imports ~f:(fun import -> [
         "    and module " ^ import.Context.schema_name ^ " = " ^
           import.Context.module_name ^ ".Make(MessageWrapper)";
@@ -95,8 +97,8 @@ let functor_sig ~context = [
 
 let mod_functor_header = [
   "module Make (MessageWrapper : Capnp.MessageSig.S) = struct";
-  "  type 'a reader_t = ro MessageWrapper.StructStorage.t option";
-  "  type 'a builder_t = rw MessageWrapper.StructStorage.t";
+  "  type 'a reader_t = 'a MessageWrapper.StructStorage.reader_t";
+  "  type 'a builder_t = 'a MessageWrapper.StructStorage.builder_t";
   "  module CamlBytes = Bytes";
 ]
 

--- a/src/compiler/pluginSchema.ml
+++ b/src/compiler/pluginSchema.ml
@@ -1423,8 +1423,8 @@ module type S = sig
 end
 
 module Make (MessageWrapper : Capnp.MessageSig.S) = struct
-  type 'a reader_t = ro MessageWrapper.StructStorage.t option
-  type 'a builder_t = rw MessageWrapper.StructStorage.t
+  type 'a reader_t = 'a MessageWrapper.StructStorage.reader_t
+  type 'a builder_t = 'a MessageWrapper.StructStorage.builder_t
   module CamlBytes = Bytes
   module DefaultsMessage_ = Capnp.BytesMessage
 
@@ -1739,11 +1739,11 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
       let file_get x = ()
-      let struct_get x = x
-      let enum_get x = x
-      let interface_get x = x
-      let const_get x = x
-      let annotation_get x = x
+      let struct_get x = RA_.cast_struct x
+      let enum_get x = RA_.cast_struct x
+      let interface_get x = RA_.cast_struct x
+      let const_get x = RA_.cast_struct x
+      let annotation_get x = RA_.cast_struct x
       type unnamed_union_t =
         | File
         | Struct of Struct.t
@@ -1857,10 +1857,10 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let of_message x = RA_.get_root_struct (RA_.Message.readonly x)
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
-      let no_discriminant =
+      let no_discriminant : int =
         65535
-      let slot_get x = x
-      let group_get x = x
+      let slot_get x = RA_.cast_struct x
+      let group_get x = RA_.cast_struct x
       type unnamed_union_t =
         | Slot of Slot.t
         | Group of Group.t
@@ -1886,7 +1886,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         Capnp.Array.to_array (annotations_get x)
       let discriminant_value_get x =
         RA_.get_uint16 ~default:65535 x 2
-      let ordinal_get x = x
+      let ordinal_get x = RA_.cast_struct x
       let of_message x = RA_.get_root_struct (RA_.Message.readonly x)
       let of_builder x = Some (RA_.StructStorage.readonly x)
     end
@@ -2069,9 +2069,9 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           let of_message x = RA_.get_root_struct (RA_.Message.readonly x)
           let of_builder x = Some (RA_.StructStorage.readonly x)
         end
-        let unconstrained_get x = x
-        let parameter_get x = x
-        let implicit_method_parameter_get x = x
+        let unconstrained_get x = RA_.cast_struct x
+        let parameter_get x = RA_.cast_struct x
+        let implicit_method_parameter_get x = RA_.cast_struct x
         type unnamed_union_t =
           | Unconstrained of Unconstrained.t
           | Parameter of Parameter.t
@@ -2100,11 +2100,11 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let float64_get x = ()
       let text_get x = ()
       let data_get x = ()
-      let list_get x = x
-      let enum_get x = x
-      let struct_get x = x
-      let interface_get x = x
-      let any_pointer_get x = x
+      let list_get x = RA_.cast_struct x
+      let enum_get x = RA_.cast_struct x
+      let struct_get x = RA_.cast_struct x
+      let interface_get x = RA_.cast_struct x
+      let any_pointer_get x = RA_.cast_struct x
       type unnamed_union_t =
         | Void
         | Bool
@@ -2717,7 +2717,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let file_get x = ()
       let file_set x =
         BA_.set_void ~discr:{BA_.Discr.value=0; BA_.Discr.byte_ofs=12} x
-      let struct_get x = x
+      let struct_get x = BA_.cast_struct x
       let struct_init x =
         let data = x.BA_.NM.StructStorage.data in
         let pointers = x.BA_.NM.StructStorage.pointers in
@@ -2741,8 +2741,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           let () = BA_.BOps.deep_zero_pointer ptr in
           MessageWrapper.Slice.set_int64 ptr 0 0L
         in
-        x
-      let enum_get x = x
+        BA_.cast_struct x
+      let enum_get x = BA_.cast_struct x
       let enum_init x =
         let data = x.BA_.NM.StructStorage.data in
         let pointers = x.BA_.NM.StructStorage.pointers in
@@ -2760,8 +2760,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           let () = BA_.BOps.deep_zero_pointer ptr in
           MessageWrapper.Slice.set_int64 ptr 0 0L
         in
-        x
-      let interface_get x = x
+        BA_.cast_struct x
+      let interface_get x = BA_.cast_struct x
       let interface_init x =
         let data = x.BA_.NM.StructStorage.data in
         let pointers = x.BA_.NM.StructStorage.pointers in
@@ -2788,8 +2788,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           let () = BA_.BOps.deep_zero_pointer ptr in
           MessageWrapper.Slice.set_int64 ptr 0 0L
         in
-        x
-      let const_get x = x
+        BA_.cast_struct x
+      let const_get x = BA_.cast_struct x
       let const_init x =
         let data = x.BA_.NM.StructStorage.data in
         let pointers = x.BA_.NM.StructStorage.pointers in
@@ -2816,8 +2816,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           let () = BA_.BOps.deep_zero_pointer ptr in
           MessageWrapper.Slice.set_int64 ptr 0 0L
         in
-        x
-      let annotation_get x = x
+        BA_.cast_struct x
+      let annotation_get x = BA_.cast_struct x
       let annotation_init x =
         let data = x.BA_.NM.StructStorage.data in
         let pointers = x.BA_.NM.StructStorage.pointers in
@@ -2847,7 +2847,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let () = BA_.set_bit ~default:false x ~byte_ofs:15 ~bit_ofs:1 false in
         let () = BA_.set_bit ~default:false x ~byte_ofs:15 ~bit_ofs:2 false in
         let () = BA_.set_bit ~default:false x ~byte_ofs:15 ~bit_ofs:3 false in
-        x
+        BA_.cast_struct x
       type unnamed_union_t =
         | File
         | Struct of Struct.t
@@ -3054,9 +3054,9 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let init_pointer ptr =
           BA_.init_struct_pointer ptr ~data_words:3 ~pointer_words:4
       end
-      let no_discriminant =
+      let no_discriminant : int =
         65535
-      let slot_get x = x
+      let slot_get x = BA_.cast_struct x
       let slot_init x =
         let data = x.BA_.NM.StructStorage.data in
         let pointers = x.BA_.NM.StructStorage.pointers in
@@ -3085,8 +3085,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           MessageWrapper.Slice.set_int64 ptr 0 0L
         in
         let () = BA_.set_bit ~default:false x ~byte_ofs:16 ~bit_ofs:0 false in
-        x
-      let group_get x = x
+        BA_.cast_struct x
+      let group_get x = BA_.cast_struct x
       let group_init x =
         let data = x.BA_.NM.StructStorage.data in
         let pointers = x.BA_.NM.StructStorage.pointers in
@@ -3096,7 +3096,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           (Some {BA_.Discr.value=1; BA_.Discr.byte_ofs=8})
         in
         let () = BA_.set_int64 ~default:0L x 16 0L in
-        x
+        BA_.cast_struct x
       type unnamed_union_t =
         | Slot of Slot.t
         | Group of Group.t
@@ -3140,7 +3140,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         BA_.get_uint16 ~default:65535 x 2
       let discriminant_value_set_exn x v =
         BA_.set_uint16 ~default:65535 x 2 v
-      let ordinal_get x = x
+      let ordinal_get x = BA_.cast_struct x
       let ordinal_init x =
         let data = x.BA_.NM.StructStorage.data in
         let pointers = x.BA_.NM.StructStorage.pointers in
@@ -3148,7 +3148,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let () = ignore pointers in
         let () = BA_.set_int16 ~default:0 x 10 0 in
         let () = BA_.set_int16 ~default:0 x 12 0 in
-        x
+        BA_.cast_struct x
       let of_message x = BA_.get_root_struct ~data_words:3 ~pointer_words:4 x
       let to_message x = x.BA_.NM.StructStorage.data.MessageWrapper.Slice.msg
       let to_reader x = Some (RA_.StructStorage.readonly x)
@@ -3505,7 +3505,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           let init_pointer ptr =
             BA_.init_struct_pointer ptr ~data_words:3 ~pointer_words:1
         end
-        let unconstrained_get x = x
+        let unconstrained_get x = BA_.cast_struct x
         let unconstrained_init x =
           let data = x.BA_.NM.StructStorage.data in
           let pointers = x.BA_.NM.StructStorage.pointers in
@@ -3515,8 +3515,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
             (Some {BA_.Discr.value=0; BA_.Discr.byte_ofs=8})
           in
           let () = BA_.set_int16 ~default:0 x 10 0 in
-          x
-        let parameter_get x = x
+          BA_.cast_struct x
+        let parameter_get x = BA_.cast_struct x
         let parameter_init x =
           let data = x.BA_.NM.StructStorage.data in
           let pointers = x.BA_.NM.StructStorage.pointers in
@@ -3527,8 +3527,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           in
           let () = BA_.set_int64 ~default:0L x 16 0L in
           let () = BA_.set_int16 ~default:0 x 10 0 in
-          x
-        let implicit_method_parameter_get x = x
+          BA_.cast_struct x
+        let implicit_method_parameter_get x = BA_.cast_struct x
         let implicit_method_parameter_init x =
           let data = x.BA_.NM.StructStorage.data in
           let pointers = x.BA_.NM.StructStorage.pointers in
@@ -3538,7 +3538,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
             (Some {BA_.Discr.value=2; BA_.Discr.byte_ofs=8})
           in
           let () = BA_.set_int16 ~default:0 x 10 0 in
-          x
+          BA_.cast_struct x
         type unnamed_union_t =
           | Unconstrained of Unconstrained.t
           | Parameter of Parameter.t
@@ -3600,7 +3600,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let data_get x = ()
       let data_set x =
         BA_.set_void ~discr:{BA_.Discr.value=13; BA_.Discr.byte_ofs=0} x
-      let list_get x = x
+      let list_get x = BA_.cast_struct x
       let list_init x =
         let data = x.BA_.NM.StructStorage.data in
         let pointers = x.BA_.NM.StructStorage.pointers in
@@ -3618,8 +3618,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           let () = BA_.BOps.deep_zero_pointer ptr in
           MessageWrapper.Slice.set_int64 ptr 0 0L
         in
-        x
-      let enum_get x = x
+        BA_.cast_struct x
+      let enum_get x = BA_.cast_struct x
       let enum_init x =
         let data = x.BA_.NM.StructStorage.data in
         let pointers = x.BA_.NM.StructStorage.pointers in
@@ -3638,8 +3638,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           let () = BA_.BOps.deep_zero_pointer ptr in
           MessageWrapper.Slice.set_int64 ptr 0 0L
         in
-        x
-      let struct_get x = x
+        BA_.cast_struct x
+      let struct_get x = BA_.cast_struct x
       let struct_init x =
         let data = x.BA_.NM.StructStorage.data in
         let pointers = x.BA_.NM.StructStorage.pointers in
@@ -3658,8 +3658,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           let () = BA_.BOps.deep_zero_pointer ptr in
           MessageWrapper.Slice.set_int64 ptr 0 0L
         in
-        x
-      let interface_get x = x
+        BA_.cast_struct x
+      let interface_get x = BA_.cast_struct x
       let interface_init x =
         let data = x.BA_.NM.StructStorage.data in
         let pointers = x.BA_.NM.StructStorage.pointers in
@@ -3678,8 +3678,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           let () = BA_.BOps.deep_zero_pointer ptr in
           MessageWrapper.Slice.set_int64 ptr 0 0L
         in
-        x
-      let any_pointer_get x = x
+        BA_.cast_struct x
+      let any_pointer_get x = BA_.cast_struct x
       let any_pointer_init x =
         let data = x.BA_.NM.StructStorage.data in
         let pointers = x.BA_.NM.StructStorage.pointers in
@@ -3693,7 +3693,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let () = BA_.set_int64 ~default:0L x 16 0L in
         let () = BA_.set_int16 ~default:0 x 10 0 in
         let () = BA_.set_int16 ~default:0 x 10 0 in
-        x
+        BA_.cast_struct x
       type unnamed_union_t =
         | Void
         | Bool

--- a/src/compiler/pluginSchema.mli
+++ b/src/compiler/pluginSchema.mli
@@ -1426,5 +1426,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) :
   (S with type 'cap message_t = 'cap MessageWrapper.Message.t
     and type Reader.pointer_t = ro MessageWrapper.Slice.t option
     and type Builder.pointer_t = rw MessageWrapper.Slice.t
+    and type 'a reader_t = 'a MessageWrapper.StructStorage.reader_t
+    and type 'a builder_t = 'a MessageWrapper.StructStorage.builder_t
 )
 

--- a/src/runtime/builderInc.ml
+++ b/src/runtime/builderInc.ml
@@ -185,7 +185,7 @@ module Make (NM : MessageSig.S) = struct
         let dest = NC.struct_of_pointer_slice slice in
         BOps.deep_copy_struct_to_dest ~src:v ~dest
       in
-      let composite_decoder x = x in
+      let composite_decoder x = NC.StructStorage.cast x in
       let composite_encoder v dest = BOps.deep_copy_struct_to_dest ~src:v ~dest in
       NC.ListCodecs.Struct {
         NC.ListCodecs.bytes     = (bytes_decoder, bytes_encoder);
@@ -231,7 +231,7 @@ module Make (NM : MessageSig.S) = struct
        supplied, then the discriminant is also set as a side-effect. *)
     let get_data_region
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
       : rw NM.Slice.t =
       let data = struct_storage.NM.StructStorage.data in
       let () = set_opt_discriminant data discr in
@@ -239,7 +239,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_bit
        ~(default : bool)
-       (struct_storage : rw NM.StructStorage.t)
+       (struct_storage : (rw, _) NM.StructStorage.t)
        ~(byte_ofs : int)
        ~(bit_ofs : int)
       : bool =
@@ -253,7 +253,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_int8
         ~(default : int)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
       : int =
       let data = struct_storage.NM.StructStorage.data in
@@ -262,7 +262,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_int16
         ~(default : int)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
       : int =
       let data = struct_storage.NM.StructStorage.data in
@@ -271,7 +271,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_int32
         ~(default : int32)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
         : int32 =
       let data = struct_storage.NM.StructStorage.data in
@@ -280,7 +280,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_int64
         ~(default : int64)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
       : int64 =
       let data = struct_storage.NM.StructStorage.data in
@@ -289,7 +289,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_uint8
         ~(default : int)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
       : int =
       let data = struct_storage.NM.StructStorage.data in
@@ -298,7 +298,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_uint16
         ~(default : int)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
       : int =
       let data = struct_storage.NM.StructStorage.data in
@@ -307,7 +307,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_uint32
         ~(default : Uint32.t)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
       : Uint32.t =
       let data = struct_storage.NM.StructStorage.data in
@@ -316,7 +316,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_uint64
         ~(default : Uint64.t)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
       : Uint64.t =
       let data = struct_storage.NM.StructStorage.data in
@@ -325,7 +325,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_float32
         ~(default_bits : int32)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
       : float =
       let data = struct_storage.NM.StructStorage.data in
@@ -335,7 +335,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_float64
         ~(default_bits : int64)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
       : float =
       let data = struct_storage.NM.StructStorage.data in
@@ -350,7 +350,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_void
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
       : unit =
       let data = struct_storage.NM.StructStorage.data in
       set_opt_discriminant data discr
@@ -358,7 +358,7 @@ module Make (NM : MessageSig.S) = struct
     let set_bit
         ?(discr : Discr.t option)
         ~(default : bool)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         ~(byte_ofs : int)
         ~(bit_ofs : int)
         (value : bool)
@@ -376,7 +376,7 @@ module Make (NM : MessageSig.S) = struct
     let set_int8
         ?(discr : Discr.t option)
         ~(default : int)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
         (value : int)
       : unit =
@@ -387,7 +387,7 @@ module Make (NM : MessageSig.S) = struct
     let set_int16
         ?(discr : Discr.t option)
         ~(default : int)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
         (value : int)
       : unit =
@@ -398,7 +398,7 @@ module Make (NM : MessageSig.S) = struct
     let set_int32
         ?(discr : Discr.t option)
         ~(default : int32)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
         (value : int32)
       : unit =
@@ -409,7 +409,7 @@ module Make (NM : MessageSig.S) = struct
     let set_int64
         ?(discr : Discr.t option)
         ~(default : int64)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
         (value : int64)
       : unit =
@@ -420,7 +420,7 @@ module Make (NM : MessageSig.S) = struct
     let set_uint8
         ?(discr : Discr.t option)
         ~(default : int)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
         (value : int)
       : unit =
@@ -431,7 +431,7 @@ module Make (NM : MessageSig.S) = struct
     let set_uint16
         ?(discr : Discr.t option)
         ~(default : int)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
         (value : int)
       : unit =
@@ -442,7 +442,7 @@ module Make (NM : MessageSig.S) = struct
     let set_uint32
         ?(discr : Discr.t option)
         ~(default : Uint32.t)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
         (value : Uint32.t)
       : unit =
@@ -453,7 +453,7 @@ module Make (NM : MessageSig.S) = struct
     let set_uint64
         ?(discr : Discr.t option)
         ~(default : Uint64.t)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
         (value : Uint64.t)
       : unit =
@@ -464,7 +464,7 @@ module Make (NM : MessageSig.S) = struct
     let set_float32
         ?(discr : Discr.t option)
         ~(default_bits : int32)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
         (value : float)
       : unit =
@@ -476,7 +476,7 @@ module Make (NM : MessageSig.S) = struct
     let set_float64
         ?(discr : Discr.t option)
         ~(default_bits : int64)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
         (value : float)
       : unit =
@@ -491,7 +491,7 @@ module Make (NM : MessageSig.S) = struct
      *******************************************************************************)
 
     let has_field
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : bool =
       let pointers = struct_storage.NM.StructStorage.pointers in
@@ -504,7 +504,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_text
         ~(default : string)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : string =
       let pointers = struct_storage.NM.StructStorage.pointers in
@@ -528,7 +528,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_blob
         ~(default : string)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : string =
       let pointers = struct_storage.NM.StructStorage.pointers in
@@ -570,7 +570,7 @@ module Make (NM : MessageSig.S) = struct
         ?(default : ro DM.ListStorage.t option)
         ~(storage_type : ListStorageType.t)
         ~(codecs : 'a NC.ListCodecs.t)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, 'a, rw NM.ListStorage.t) InnerArray.t =
       let create_default message =
@@ -599,7 +599,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_void_list
         ?(default : ro DM.ListStorage.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, unit, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Empty
@@ -607,7 +607,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_bit_list
         ?(default : ro DM.ListStorage.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, bool, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Bit
@@ -615,7 +615,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_int8_list
         ?(default : ro DM.ListStorage.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, int, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Bytes1
@@ -623,7 +623,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_int16_list
         ?(default : ro DM.ListStorage.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, int, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Bytes2
@@ -631,7 +631,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_int32_list
         ?(default : ro DM.ListStorage.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, int32, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Bytes4
@@ -639,7 +639,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_int64_list
         ?(default : ro DM.ListStorage.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, int64, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Bytes8
@@ -647,7 +647,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_uint8_list
         ?(default : ro DM.ListStorage.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, int, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Bytes1
@@ -655,7 +655,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_uint16_list
         ?(default : ro DM.ListStorage.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, int, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Bytes2
@@ -663,7 +663,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_uint32_list
         ?(default : ro DM.ListStorage.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, Uint32.t, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Bytes4
@@ -671,7 +671,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_uint64_list
         ?(default : ro DM.ListStorage.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, Uint64.t, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Bytes8
@@ -679,7 +679,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_float32_list
         ?(default : ro DM.ListStorage.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, float, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Bytes4
@@ -687,7 +687,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_float64_list
         ?(default : ro DM.ListStorage.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, float, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Bytes8
@@ -695,7 +695,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_text_list
         ?(default : ro DM.ListStorage.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, string, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Pointer
@@ -703,7 +703,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_blob_list
         ?(default : ro DM.ListStorage.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : (rw, string, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Pointer
@@ -713,9 +713,9 @@ module Make (NM : MessageSig.S) = struct
         ?(default : ro DM.ListStorage.t option)
         ~(data_words : int)
         ~(pointer_words : int)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
-      : (rw, rw NM.StructStorage.t, rw NM.ListStorage.t) InnerArray.t =
+      : (rw, (rw, _) NM.StructStorage.t, rw NM.ListStorage.t) InnerArray.t =
       get_list ~struct_sizes:{
         BuilderOps.StructSizes.data_words;
         BuilderOps.StructSizes.pointer_words }
@@ -724,12 +724,12 @@ module Make (NM : MessageSig.S) = struct
         ~codecs:struct_list_codecs struct_storage pointer_word
 
     let get_struct
-        ?(default : ro DM.StructStorage.t option)
+        ?(default : (ro, 'a) DM.StructStorage.t option)
         ~(data_words : int)
         ~(pointer_words : int)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
-      : rw NM.StructStorage.t =
+      : (rw, 'a) NM.StructStorage.t =
       let create_default message =
         match default with
         | Some default_storage ->
@@ -752,7 +752,7 @@ module Make (NM : MessageSig.S) = struct
 
     let get_pointer
         ?(default : ro DM.Slice.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : rw NM.Slice.t =
       let pointers = struct_storage.NM.StructStorage.pointers in
@@ -780,7 +780,7 @@ module Make (NM : MessageSig.S) = struct
       pointer_bytes
 
     let get_interface
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
       : Uint32.t option =
       let pointers = struct_storage.NM.StructStorage.pointers in
@@ -808,7 +808,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_text
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : string)
       : unit =
@@ -832,7 +832,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_blob
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : string)
       : unit =
@@ -858,7 +858,7 @@ module Make (NM : MessageSig.S) = struct
         ?(struct_sizes : BuilderOps.StructSizes.t option)
         ~(storage_type : ListStorageType.t)
         ~(codecs : 'a NC.ListCodecs.t)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : 'cap NM.ListStorage.t option)
       : (rw, 'a, rw NM.ListStorage.t) InnerArray.t =
@@ -890,7 +890,7 @@ module Make (NM : MessageSig.S) = struct
         ?(struct_sizes : BuilderOps.StructSizes.t option)
         ~(storage_type : ListStorageType.t)
         ~(codecs : 'a NC.ListCodecs.t)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, 'a, 'cap2 NM.ListStorage.t) InnerArray.t)
       : (rw, 'a, rw NM.ListStorage.t) InnerArray.t =
@@ -900,7 +900,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_void_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, unit, 'cap2 NM.ListStorage.t) InnerArray.t)
       : (rw, unit, rw NM.ListStorage.t) InnerArray.t =
@@ -909,7 +909,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_bit_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, bool, 'cap2 NM.ListStorage.t) InnerArray.t)
       : (rw, bool, rw NM.ListStorage.t) InnerArray.t =
@@ -918,7 +918,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_int8_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, int, 'cap2 NM.ListStorage.t) InnerArray.t)
       : (rw, int, 'cap NM.ListStorage.t) InnerArray.t =
@@ -927,7 +927,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_int16_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, int, 'cap2 NM.ListStorage.t) InnerArray.t)
       : (rw, int, 'cap NM.ListStorage.t) InnerArray.t =
@@ -936,7 +936,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_int32_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, int32, 'cap NM.ListStorage.t) InnerArray.t)
       : (rw, int32, rw NM.ListStorage.t) InnerArray.t =
@@ -945,7 +945,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_int64_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, int64, 'cap2 NM.ListStorage.t) InnerArray.t)
       : (rw, int64, rw NM.ListStorage.t) InnerArray.t =
@@ -954,7 +954,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_uint8_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, int, 'cap2 NM.ListStorage.t) InnerArray.t)
       : (rw, int, rw NM.ListStorage.t) InnerArray.t =
@@ -963,7 +963,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_uint16_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, int, 'cap2 NM.ListStorage.t) InnerArray.t)
       : (rw, int, rw NM.ListStorage.t) InnerArray.t =
@@ -972,7 +972,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_uint32_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, Uint32.t, 'cap2 NM.ListStorage.t) InnerArray.t)
       : (rw, Uint32.t, rw NM.ListStorage.t) InnerArray.t =
@@ -981,7 +981,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_uint64_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, Uint64.t, 'cap2 NM.ListStorage.t) InnerArray.t)
       : (rw, Uint64.t, rw NM.ListStorage.t) InnerArray.t =
@@ -990,7 +990,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_float32_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, float, 'cap2 NM.ListStorage.t) InnerArray.t)
       : (rw, float, rw NM.ListStorage.t) InnerArray.t =
@@ -999,7 +999,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_float64_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, float, 'cap2 NM.ListStorage.t) InnerArray.t)
       : (rw, float, rw NM.ListStorage.t) InnerArray.t =
@@ -1008,7 +1008,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_text_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, string, 'cap2 NM.ListStorage.t) InnerArray.t)
       : (rw, string, rw NM.ListStorage.t) InnerArray.t =
@@ -1017,7 +1017,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_blob_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : ('cap1, string, 'cap2 NM.ListStorage.t) InnerArray.t)
       : (rw, string, rw NM.ListStorage.t) InnerArray.t =
@@ -1029,10 +1029,10 @@ module Make (NM : MessageSig.S) = struct
         ~(data_words : int)
         ~(pointer_words : int)
         (* FIXME: this won't allow assignment from Reader struct lists *)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
-        (value : ('cap1, 'cap2 NM.StructStorage.t, 'cap2 NM.ListStorage.t) InnerArray.t)
-      : (rw, rw NM.StructStorage.t, rw NM.ListStorage.t) InnerArray.t =
+        (value : ('cap1, ('cap2, _) NM.StructStorage.t, 'cap2 NM.ListStorage.t) InnerArray.t)
+      : (rw, (rw, _) NM.StructStorage.t, rw NM.ListStorage.t) InnerArray.t =
       set_list ?discr ~struct_sizes:{
         BuilderOps.StructSizes.data_words;
         BuilderOps.StructSizes.pointer_words }
@@ -1043,10 +1043,10 @@ module Make (NM : MessageSig.S) = struct
         ?(discr : Discr.t option)
         ~(data_words : int)
         ~(pointer_words : int)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
-        (value : 'cap NM.StructStorage.t option)
-      : rw NM.StructStorage.t =
+        (value : ('cap, 'a) NM.StructStorage.t option)
+      : (rw, 'a) NM.StructStorage.t =
       let pointers = struct_storage.NM.StructStorage.pointers in
       let num_pointers = pointers.NM.Slice.len / sizeof_uint64 in
       (* Struct should have already been upgraded to at least the
@@ -1072,7 +1072,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_pointer
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : 'cap NM.Slice.t option)
       : rw NM.Slice.t =
@@ -1097,7 +1097,7 @@ module Make (NM : MessageSig.S) = struct
 
     let set_interface
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (value : Uint32.t option)
       : unit =
@@ -1127,7 +1127,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_blob
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : unit =
@@ -1138,7 +1138,7 @@ module Make (NM : MessageSig.S) = struct
         ?(discr : Discr.t option)
         ~(storage_type : ListStorageType.t)
         ~(codecs : 'a NC.ListCodecs.t)
-        (struct_storage : 'cap NM.StructStorage.t)
+        (struct_storage : ('cap, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, 'a, rw NM.ListStorage.t) InnerArray.t =
@@ -1159,7 +1159,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_void_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, unit, rw NM.ListStorage.t) InnerArray.t =
@@ -1168,7 +1168,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_bit_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, bool, rw NM.ListStorage.t) InnerArray.t =
@@ -1177,7 +1177,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_int8_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, int, rw NM.ListStorage.t) InnerArray.t =
@@ -1186,7 +1186,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_int16_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, int, rw NM.ListStorage.t) InnerArray.t =
@@ -1195,7 +1195,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_int32_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, int32, rw NM.ListStorage.t) InnerArray.t =
@@ -1204,7 +1204,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_int64_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, int64, rw NM.ListStorage.t) InnerArray.t =
@@ -1213,7 +1213,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_uint8_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, int, rw NM.ListStorage.t) InnerArray.t =
@@ -1222,7 +1222,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_uint16_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, int, rw NM.ListStorage.t) InnerArray.t =
@@ -1231,7 +1231,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_uint32_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, Uint32.t, rw NM.ListStorage.t) InnerArray.t =
@@ -1240,7 +1240,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_uint64_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, Uint64.t, rw NM.ListStorage.t) InnerArray.t =
@@ -1249,7 +1249,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_float32_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, float, rw NM.ListStorage.t) InnerArray.t =
@@ -1258,7 +1258,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_float64_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, float, rw NM.ListStorage.t) InnerArray.t =
@@ -1267,7 +1267,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_text_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, string, rw NM.ListStorage.t) InnerArray.t =
@@ -1276,7 +1276,7 @@ module Make (NM : MessageSig.S) = struct
 
     let init_blob_list
         ?(discr : Discr.t option)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
       : (rw, string, rw NM.ListStorage.t) InnerArray.t =
@@ -1287,10 +1287,10 @@ module Make (NM : MessageSig.S) = struct
         ?(discr : Discr.t option)
         ~(data_words : int)
         ~(pointer_words : int)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
-      : (rw, rw NM.StructStorage.t, rw NM.ListStorage.t) InnerArray.t =
+      : (rw, (rw, _) NM.StructStorage.t, rw NM.ListStorage.t) InnerArray.t =
       init_list ?discr ~storage_type:(
         ListStorageType.Composite (data_words, pointer_words))
         struct_storage pointer_word ~codecs:struct_list_codecs num_elements
@@ -1299,9 +1299,9 @@ module Make (NM : MessageSig.S) = struct
         ?(discr : Discr.t option)
         ~(data_words : int)
         ~(pointer_words : int)
-        (struct_storage : rw NM.StructStorage.t)
+        (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
-      : rw NM.StructStorage.t =
+      : (rw, _) NM.StructStorage.t =
       let pointers = struct_storage.NM.StructStorage.pointers in
       let num_pointers = pointers.NM.Slice.len / sizeof_uint64 in
       (* Struct should have already been upgraded to at least the
@@ -1324,7 +1324,7 @@ module Make (NM : MessageSig.S) = struct
         pointer_bytes
         ~(data_words : int)
         ~(pointer_words : int)
-      : rw NM.StructStorage.t =
+      : (rw, _) NM.StructStorage.t =
       let () = BOps.deep_zero_pointer pointer_bytes in
       let storage =
         BOps.alloc_struct_storage pointer_bytes.NM.Slice.msg ~data_words ~pointer_words
@@ -1338,7 +1338,7 @@ module Make (NM : MessageSig.S) = struct
         (m : rw NM.Message.t)
         ~(data_words : int)
         ~(pointer_words : int)
-      : rw NM.StructStorage.t =
+      : (rw, _) NM.StructStorage.t =
       let first_segment = NM.Message.get_segment m 0 in
       if NM.Segment.length first_segment < sizeof_uint64 then
         invalid_msg "message is too small to contain root struct pointer"
@@ -1365,7 +1365,7 @@ module Make (NM : MessageSig.S) = struct
         ~(data_words : int)
         ~(pointer_words : int)
         ()
-      : rw NM.StructStorage.t =
+      : (rw, _) NM.StructStorage.t =
       let act_message_size =
         let requested_size =
           match message_size with
@@ -1383,5 +1383,7 @@ module Make (NM : MessageSig.S) = struct
     let pointers_struct pointers =
       let data = { pointers with NM.Slice.len = 0 } in
       NM.StructStorage.v ~data ~pointers
+
+    let cast_struct = NM.StructStorage.cast
   end
 end

--- a/src/runtime/builderInc.ml
+++ b/src/runtime/builderInc.ml
@@ -1380,5 +1380,8 @@ module Make (NM : MessageSig.S) = struct
       let _ = NM.Slice.alloc message sizeof_uint64 in
       get_root_struct message ~data_words ~pointer_words
 
+    let pointers_struct pointers =
+      let data = { pointers with NM.Slice.len = 0 } in
+      NM.StructStorage.v ~data ~pointers
   end
 end

--- a/src/runtime/builderOps.ml
+++ b/src/runtime/builderOps.ml
@@ -61,7 +61,7 @@ module Make (ROM : MessageSig.S) (RWM : MessageSig.S) = struct
   (* Given storage for a struct, get the pointer bytes for the given
      struct-relative pointer index. *)
   let get_struct_pointer
-      (struct_storage : 'cap RWM.StructStorage.t)
+      (struct_storage : ('cap, _) RWM.StructStorage.t)
       (pointer_word : int)
     : 'cap RWM.Slice.t =
     let pointers = struct_storage.RWM.StructStorage.pointers in
@@ -81,7 +81,7 @@ module Make (ROM : MessageSig.S) (RWM : MessageSig.S) = struct
       (message : rw RWM.Message.t)
       ~(data_words : int)
       ~(pointer_words : int)
-    : rw RWM.StructStorage.t =
+    : (rw, 'a) RWM.StructStorage.t =
     let storage = RWM.Slice.alloc message
       ((data_words + pointer_words) * sizeof_uint64)
     in
@@ -277,7 +277,7 @@ module Make (ROM : MessageSig.S) (RWM : MessageSig.S) = struct
      storage. *)
   let init_normal_struct_pointer
       (pointer_bytes : rw RWM.Slice.t)
-      (struct_storage : 'cap RWM.StructStorage.t)
+      (struct_storage : ('cap, _) RWM.StructStorage.t)
     : unit =
     let () = assert (struct_storage.RWM.StructStorage.data.RWM.Slice.segment_id =
       pointer_bytes.RWM.Slice.segment_id)
@@ -298,7 +298,7 @@ module Make (ROM : MessageSig.S) (RWM : MessageSig.S) = struct
      struct storage. *)
   let init_struct_pointer
       (pointer_bytes : rw RWM.Slice.t)
-      (struct_storage : 'cap RWM.StructStorage.t)
+      (struct_storage : ('cap, _) RWM.StructStorage.t)
     : unit =
     if struct_storage.RWM.StructStorage.data.RWM.Slice.segment_id =
         pointer_bytes.RWM.Slice.segment_id then
@@ -351,8 +351,8 @@ module Make (ROM : MessageSig.S) (RWM : MessageSig.S) = struct
      is a shallow copy; the data section is copied in bitwise fashion,
      and the pointers are copied using [shallow_copy_pointer]. *)
   let shallow_copy_struct
-      ~(src : 'cap RWM.StructStorage.t)
-      ~(dest : rw RWM.StructStorage.t)
+      ~(src : ('cap, _) RWM.StructStorage.t)
+      ~(dest : (rw, _) RWM.StructStorage.t)
     : unit =
     let open RWM.StructStorage in
     let data_copy_size =
@@ -453,7 +453,7 @@ module Make (ROM : MessageSig.S) (RWM : MessageSig.S) = struct
 
   (* Set a struct to all-zeros.  Pointers are not followed. *)
   let shallow_zero_out_struct
-      (struct_storage : rw RWM.StructStorage.t)
+      (struct_storage : (rw, _) RWM.StructStorage.t)
     : unit =
     let open RWM.StructStorage in
     RWM.Slice.zero_out struct_storage.data
@@ -471,10 +471,10 @@ module Make (ROM : MessageSig.S) (RWM : MessageSig.S) = struct
      Returns: new struct descriptor (possibly the same as the old one). *)
   let upgrade_struct
       (pointer_bytes : rw RWM.Slice.t)
-      (orig : rw RWM.StructStorage.t)
+      (orig : (rw, _) RWM.StructStorage.t)
       ~(data_words : int)
       ~(pointer_words : int)
-    : rw RWM.StructStorage.t =
+    : (rw, _) RWM.StructStorage.t =
     let open RWM.StructStorage in
     if orig.data.RWM.Slice.len < data_words * sizeof_uint64 ||
        orig.pointers.RWM.Slice.len < pointer_words * sizeof_uint64 then
@@ -496,11 +496,11 @@ module Make (ROM : MessageSig.S) (RWM : MessageSig.S) = struct
      if the struct has a smaller layout (i.e. from an older protocol version),
      then a new struct is allocated and the data is copied over. *)
   let deref_struct_pointer
-      ~(create_default : rw RWM.Message.t -> rw RWM.StructStorage.t)
+      ~(create_default : rw RWM.Message.t -> (rw, 'a) RWM.StructStorage.t)
       ~(data_words : int)
       ~(pointer_words : int)
       (pointer_bytes : rw RWM.Slice.t)
-    : rw RWM.StructStorage.t =
+    : (rw, 'a) RWM.StructStorage.t =
     match RReader.deref_struct_pointer pointer_bytes with
     | None ->
         let struct_storage = create_default pointer_bytes.RWM.Slice.msg in
@@ -549,11 +549,11 @@ module Make (ROM : MessageSig.S) (RWM : MessageSig.S) = struct
      during a schema upgrade).
   *)
   and deep_copy_struct
-      ~(src : 'cap ROM.StructStorage.t)
+      ~(src : ('cap, _) ROM.StructStorage.t)
       ~(dest_message : rw RWM.Message.t)
       ~(data_words : int)
       ~(pointer_words : int)
-    : rw RWM.StructStorage.t =
+    : (rw, _) RWM.StructStorage.t =
     let src_data_words    = src.ROM.StructStorage.data.ROM.Slice.len / sizeof_uint64 in
     let src_pointer_words = src.ROM.StructStorage.pointers.ROM.Slice.len / sizeof_uint64 in
     let dest_data_words    = max data_words src_data_words in
@@ -566,8 +566,8 @@ module Make (ROM : MessageSig.S) (RWM : MessageSig.S) = struct
 
   (* As [deep_copy_struct], but the destination is already allocated. *)
   and deep_copy_struct_to_dest
-      ~(src : 'cap ROM.StructStorage.t)
-      ~(dest : rw RWM.StructStorage.t)
+      ~(src : ('cap, _) ROM.StructStorage.t)
+      ~(dest : (rw, _) RWM.StructStorage.t)
     : unit =
     let data_bytes = min
         src.ROM.StructStorage.data.ROM.Slice.len
@@ -830,7 +830,7 @@ module Make (ROM : MessageSig.S) (RWM : MessageSig.S) = struct
         RWM.Slice.zero_out content_slice ~pos:0 ~len:content_slice.RWM.Slice.len
 
   and deep_zero_struct
-    (struct_storage : rw RWM.StructStorage.t)
+    (struct_storage : (rw, _) RWM.StructStorage.t)
     : unit =
     let open RWM.StructStorage in
     let pointer_words =

--- a/src/runtime/commonInc.ml
+++ b/src/runtime/commonInc.ml
@@ -64,7 +64,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   (** Get the range of bytes associated with a pointer stored in a struct. *)
   let ss_get_pointer
-      (struct_storage : 'cap StructStorage.t)
+      (struct_storage : ('cap, 'a) StructStorage.t)
       (word : int)           (* Struct-relative pointer index *)
     : 'cap Slice.t option =  (* Returns None if storage is too small for this word *)
     let pointers = struct_storage.StructStorage.pointers in
@@ -208,7 +208,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
   let rec deref_far_pointer
       (far_pointer : FarPointer.t)
       (message : 'cap Message.t)
-    : 'cap Object.t =
+    : ('cap, 'a) Object.t =
     let open FarPointer in
     match far_pointer.landing_pad with
     | NormalPointer ->
@@ -272,7 +272,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   (* Given a range of eight bytes which represent a pointer, get the object which
      the pointer points to. *)
-  and deref_pointer (pointer_bytes : 'cap Slice.t) : 'cap Object.t =
+  and deref_pointer (pointer_bytes : 'cap Slice.t) : ('cap, 'a) Object.t =
     let pointer64 = Slice.get_int64 pointer_bytes 0 in
     if Util.is_int64_zero pointer64 then
       Object.None
@@ -327,7 +327,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
     type ('cap, 'a) struct_decoders_t = {
       bytes     : 'cap Slice.t -> 'a;
       pointer   : 'cap Slice.t -> 'a;
-      composite : 'cap StructStorage.t -> 'a;
+      composite : 'b. ('cap, 'b) StructStorage.t -> 'a;
     }
 
     type ('cap, 'a) t =
@@ -346,7 +346,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
     type 'a struct_codecs_t = {
       bytes     : (rw Slice.t -> 'a) * ('a -> rw Slice.t -> unit);
       pointer   : (rw Slice.t -> 'a) * ('a -> rw Slice.t -> unit);
-      composite : (rw StructStorage.t -> 'a) * ('a -> rw StructStorage.t -> unit);
+      composite : 'b. ((rw, 'b) StructStorage.t -> 'a) * ('a -> (rw, 'b) StructStorage.t -> unit);
     }
 
     type 'a t =

--- a/src/runtime/commonInc.ml
+++ b/src/runtime/commonInc.ml
@@ -265,7 +265,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
                 ~err:"struct-tagged far pointer describes invalid pointers region"
                 pointers
             in
-            Object.Struct { StructStorage.data; StructStorage.pointers; }
+            Object.Struct (StructStorage.v ~data ~pointers)
         | _ ->
             invalid_msg "tagged far pointer points to invalid landing pad"
 
@@ -303,7 +303,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
           let () = bounds_check_slice_exn
             ~err:"struct pointer describes invalid pointers region" pointers
           in
-          Object.Struct { StructStorage.data; StructStorage.pointers; }
+          Object.Struct (StructStorage.v ~data ~pointers)
       | 0x1 ->  (* Pointer.Bitfield.tag_val_list *)
           let list_pointer = ListPointer.decode pointer64 in
           Object.List (make_list_storage
@@ -508,7 +508,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
             Slice.start = Slice.get_end data;
             Slice.len   = pointers_size;
           } in
-          { StructStorage.data; StructStorage.pointers; }
+          StructStorage.v ~data ~pointers
         in
         let make_bytes_handler ~size ~decode =
           if data_words = 0 then
@@ -770,7 +770,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
             Slice.start = Slice.get_end data;
             Slice.len   = pointers_size;
           } in
-          { StructStorage.data; StructStorage.pointers; }
+          StructStorage.v ~data ~pointers
         in
         let make_bytes_handlers ~size ~decode ~encode =
           if data_words = 0 then
@@ -931,7 +931,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
       Slice.start = Slice.get_end data;
       Slice.len   = 0;
     } in
-    { StructStorage.data; StructStorage.pointers }
+    StructStorage.v ~data ~pointers
 
   let struct_of_pointer_slice slice =
     let () = assert (slice.Slice.len = sizeof_uint64) in
@@ -943,7 +943,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
       slice with
       Slice.len = sizeof_uint64;
     } in
-    { StructStorage.data; StructStorage.pointers }
+    StructStorage.v ~data ~pointers
 
 
   (* Given some list storage corresponding to a struct list, construct
@@ -1006,7 +1006,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
             Slice.start = Slice.get_end data;
             Slice.len   = pointers_size;
           } in
-          { StructStorage.data; StructStorage.pointers }
+          StructStorage.v ~data ~pointers
         in
         make_struct_of_list_index_composite
     | ListStorageType.Bit ->

--- a/src/runtime/message.ml
+++ b/src/runtime/message.ml
@@ -351,6 +351,8 @@ module Make (Storage : MessageStorage.S) = struct
       data     = Slice.readonly struct_storage.data;
       pointers = Slice.readonly struct_storage.pointers;
     }
+
+    let v ~data ~pointers = { data; pointers }
   end
 
   module ListStorage = struct

--- a/src/runtime/message.ml
+++ b/src/runtime/message.ml
@@ -342,17 +342,24 @@ module Make (Storage : MessageStorage.S) = struct
 
   module StructStorage = struct
     (** Storage associated with a cap'n proto struct. *)
-    type 'cap t = {
+    type ('cap, 'a) t = {
       data     : 'cap Slice.t;  (** Storage for struct fields stored by value *)
       pointers : 'cap Slice.t;  (** Storage for struct fields stored by reference *)
     }
 
-    let readonly (struct_storage : 'cap t) : ro t = {
+    let readonly (struct_storage : ('cap, 'a) t) : (ro, 'a) t = {
       data     = Slice.readonly struct_storage.data;
       pointers = Slice.readonly struct_storage.pointers;
     }
 
     let v ~data ~pointers = { data; pointers }
+
+    let cast x = (x :> ('cap, 'a) t)
+
+    type 'a reader_t = (ro, 'a) t option
+    type 'a builder_t = (rw, 'a) t
+
+    let cast_reader x = (x :> 'a reader_t)
   end
 
   module ListStorage = struct
@@ -371,10 +378,10 @@ module Make (Storage : MessageStorage.S) = struct
   end
 
   module Object = struct
-    type 'cap t =
+    type ('cap, 'a) t =
       | None
       | List of 'cap ListStorage.t
-      | Struct of 'cap StructStorage.t
+      | Struct of ('cap, 'a) StructStorage.t
       | Capability of Uint32.t
   end
 

--- a/src/runtime/messageSig.ml
+++ b/src/runtime/messageSig.ml
@@ -282,9 +282,16 @@ module type S = sig
   end
 
   module StructStorage : sig
-    type 'cap t = private { data : 'cap Slice.t; pointers : 'cap Slice.t; }
-    val readonly : 'cap t -> ro t
-    val v : data:'cap Slice.t -> pointers:'cap Slice.t -> 'cap t
+    (* Note: ['a] is marked covariant here just because it makes casting easier in some places. *)
+    type ('cap, +'a) t = private { data : 'cap Slice.t; pointers : 'cap Slice.t; }
+    val readonly : ('cap, 'a) t -> (ro, 'a) t
+    val v : data:'cap Slice.t -> pointers:'cap Slice.t -> ('cap, 'a) t
+    val cast : ('cap, 'a) t -> ('cap, 'b) t
+
+    type 'a reader_t = (ro, 'a) t option
+    type 'a builder_t = (rw, 'a) t
+
+    val cast_reader : 'a reader_t -> 'b reader_t
   end
 
   module ListStorage : sig
@@ -297,10 +304,10 @@ module type S = sig
   end
 
   module Object : sig
-    type 'cap t =
+    type ('cap, 'a) t =
       | None
       | List of 'cap ListStorage.t
-      | Struct of 'cap StructStorage.t
+      | Struct of ('cap, 'a) StructStorage.t
       | Capability of Uint32.t
   end
 end

--- a/src/runtime/messageSig.ml
+++ b/src/runtime/messageSig.ml
@@ -282,8 +282,9 @@ module type S = sig
   end
 
   module StructStorage : sig
-    type 'cap t = { data : 'cap Slice.t; pointers : 'cap Slice.t; }
+    type 'cap t = private { data : 'cap Slice.t; pointers : 'cap Slice.t; }
     val readonly : 'cap t -> ro t
+    val v : data:'cap Slice.t -> pointers:'cap Slice.t -> 'cap t
   end
 
   module ListStorage : sig

--- a/src/runtime/readerInc.ml
+++ b/src/runtime/readerInc.ml
@@ -131,22 +131,24 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let struct_list_decoders =
     let struct_decoders =
-      let bytes slice = Some {
-          StructStorage.data = slice;
-          StructStorage.pointers = {
-            slice with
-            Slice.start = Slice.get_end slice;
-            Slice.len   = 0;
-          };
-        }
+      let bytes slice = Some (
+          StructStorage.v
+            ~data:slice
+            ~pointers:{
+              slice with
+              Slice.start = Slice.get_end slice;
+              Slice.len   = 0;
+            };
+        )
       in
-      let pointer slice = Some {
-          StructStorage.data = {
-            slice with
-            Slice.len = 0;
-          };
-          StructStorage.pointers = slice;
-        }
+      let pointer slice = Some (
+          StructStorage.v
+            ~data:{
+              slice with
+              Slice.len = 0;
+            }
+            ~pointers:slice
+        )
       in
       let composite x = Some x in {
         ListDecoders.bytes;
@@ -677,4 +679,8 @@ module Make (MessageWrapper : MessageSig.S) = struct
           None
     | None ->
         None
+
+  let pointers_struct pointers =
+    let data = { pointers with Slice.len = 0 } in
+    StructStorage.v ~data ~pointers
 end [@@inline]

--- a/src/runtime/readerInc.ml
+++ b/src/runtime/readerInc.ml
@@ -62,7 +62,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
      corresponding struct storage descriptor.  Returns None if the pointer is
      null. *)
   let deref_struct_pointer (pointer_bytes : 'cap Slice.t)
-    : 'cap StructStorage.t option =
+    : ('cap, _) StructStorage.t option =
     match deref_pointer pointer_bytes with
     | Object.None ->
         None
@@ -150,7 +150,8 @@ module Make (MessageWrapper : MessageSig.S) = struct
             ~pointers:slice
         )
       in
-      let composite x = Some x in {
+      let composite x = Some (StructStorage.cast x) in
+      {
         ListDecoders.bytes;
         ListDecoders.pointer;
         ListDecoders.composite;
@@ -160,7 +161,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
 
   (* Locate the storage region corresponding to the root struct of a message. *)
-  let get_root_struct (m : 'cap Message.t) : 'cap StructStorage.t option =
+  let get_root_struct (m : 'cap Message.t) : ('cap, 'a) StructStorage.t option =
     let first_segment = Message.get_segment m 0 in
     if Segment.length first_segment < sizeof_uint64 then
       None
@@ -181,7 +182,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_bit
       ~(default : bool)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       ~(byte_ofs : int)
       ~(bit_ofs : int)
     : bool =
@@ -202,7 +203,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_int8
       ~(default : int)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (byte_ofs : int)
     : int =
     match struct_storage_opt with
@@ -218,7 +219,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_int16
       ~(default : int)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (byte_ofs : int)
     : int =
     match struct_storage_opt with
@@ -234,7 +235,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_int32
       ~(default : int32)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (byte_ofs : int)
     : int32 =
     match struct_storage_opt with
@@ -250,7 +251,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_int64
       ~(default : int64)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (byte_ofs : int)
     : int64 =
     match struct_storage_opt with
@@ -266,7 +267,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_uint8
       ~(default : int)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (byte_ofs : int)
     : int =
     match struct_storage_opt with
@@ -282,7 +283,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_uint16
       ~(default : int)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (byte_ofs : int)
     : int =
     match struct_storage_opt with
@@ -298,7 +299,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_uint32
       ~(default : Uint32.t)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (byte_ofs : int)
     : Uint32.t =
     match struct_storage_opt with
@@ -314,7 +315,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_uint64
       ~(default : Uint64.t)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (byte_ofs : int)
     : Uint64.t =
     match struct_storage_opt with
@@ -330,7 +331,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_float32
       ~(default_bits : int32)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (byte_ofs : int)
     : float =
     let numeric =
@@ -349,7 +350,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_float64
       ~(default_bits : int64)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (byte_ofs : int)
     : float =
     let numeric =
@@ -372,7 +373,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
    *******************************************************************************)
 
   let has_field
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : bool =
     match struct_storage_opt with
@@ -390,7 +391,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_text
       ~(default : string)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : string =
     match struct_storage_opt with
@@ -416,7 +417,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_blob
       ~(default : string)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : string =
     match struct_storage_opt with
@@ -443,7 +444,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
   let get_list
       ?(default : ro ListStorage.t option)
       (decoders : ('cap, 'a) ListDecoders.t)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, 'a, 'cap ListStorage.t) InnerArray.t =
     let make_default default' decoders' =
@@ -498,114 +499,114 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_void_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, unit, 'cap ListStorage.t) InnerArray.t =
     get_list ?default void_list_decoders struct_storage_opt pointer_word
 
   let get_bit_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, bool, 'cap ListStorage.t) InnerArray.t =
     get_list ?default bit_list_decoders struct_storage_opt pointer_word
 
   let get_int8_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, int, 'cap ListStorage.t) InnerArray.t =
     get_list ?default int8_list_decoders struct_storage_opt pointer_word
 
   let get_int16_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, int, 'cap ListStorage.t) InnerArray.t =
     get_list ?default int16_list_decoders struct_storage_opt pointer_word
 
   let get_int32_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, int32, 'cap ListStorage.t) InnerArray.t =
     get_list ?default int32_list_decoders struct_storage_opt pointer_word
 
   let get_int64_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, int64, 'cap ListStorage.t) InnerArray.t =
     get_list ?default int64_list_decoders struct_storage_opt pointer_word
 
   let get_uint8_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, int, 'cap ListStorage.t) InnerArray.t =
     get_list ?default uint8_list_decoders struct_storage_opt pointer_word
 
   let get_uint16_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, int, 'cap ListStorage.t) InnerArray.t =
     get_list ?default uint16_list_decoders struct_storage_opt pointer_word
 
   let get_uint32_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, Uint32.t, 'cap ListStorage.t) InnerArray.t =
     get_list ?default uint32_list_decoders struct_storage_opt pointer_word
 
   let get_uint64_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, Uint64.t, 'cap ListStorage.t) InnerArray.t =
     get_list ?default uint64_list_decoders struct_storage_opt pointer_word
 
   let get_float32_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, float, 'cap ListStorage.t) InnerArray.t =
     get_list ?default float32_list_decoders struct_storage_opt pointer_word
 
   let get_float64_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, float, 'cap ListStorage.t) InnerArray.t =
     get_list ?default float64_list_decoders struct_storage_opt pointer_word
 
   let get_text_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, string, 'cap ListStorage.t) InnerArray.t =
     get_list ?default text_list_decoders struct_storage_opt pointer_word
 
   let get_blob_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : (ro, string, 'cap ListStorage.t) InnerArray.t =
     get_list ?default blob_list_decoders struct_storage_opt pointer_word
 
   let get_struct_list
       ?(default : ro ListStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
-    : (ro, 'cap StructStorage.t option, 'cap ListStorage.t) InnerArray.t =
+    : (ro, ('cap, _) StructStorage.t option, 'cap ListStorage.t) InnerArray.t =
     get_list ?default struct_list_decoders struct_storage_opt pointer_word
 
   let get_struct
-      ?(default : ro StructStorage.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      ?(default : (ro, 'a) StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
-    : 'cap StructStorage.t option =
+    : ('cap, 'a) StructStorage.t option =
     match struct_storage_opt with
     | Some struct_storage ->
         let pointers = struct_storage.StructStorage.pointers in
@@ -629,7 +630,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
 
   let get_pointer
       ?(default: ro Slice.t option)
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : 'cap Slice.t option =
     match struct_storage_opt with
@@ -654,7 +655,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
         default
 
   let get_interface
-      (struct_storage_opt : 'cap StructStorage.t option)
+      (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
     : Uint32.t option =
     match struct_storage_opt with
@@ -683,4 +684,9 @@ module Make (MessageWrapper : MessageSig.S) = struct
   let pointers_struct pointers =
     let data = { pointers with Slice.len = 0 } in
     StructStorage.v ~data ~pointers
+
+  let cast_struct = function
+    | None -> None
+    | Some s -> Some (StructStorage.cast s)
+
 end [@@inline]


### PR DESCRIPTION
Before, each generated module defined its own types. This meant that a struct reader from one schema file (e.g. from an AnyPointer) couldn't be used with another.

This was a problem for the RPC system, which would like to give user code a request or response struct of the expected type, but this type is defined in the application's own schema file.

To support this, I have added a phantom type to `StructStorage`, and defined `StructStorage.reader_t` and `StructStorage.builder_t` types using it. The generated schema files expose that their reader and builder types are equal to these.

We don't want to expose the fact that all `StructStorage.t` types are really equal to the compiler, since then it can't detect when the user isn't following the schema. Instread, `StructStorage.t` is now private and you must use the `StructStorage.v` constructor to create them. This prevents
accidents, while not preventing the user from casting between struct types if they want to. We need to allow this anyway because the generated modules need to do this, and they have no special access to the library's internals.