### PR TITLE
Use polymorphic variants for phantom types

### DIFF
--- a/src/benchmark/capnpCarsales.ml
+++ b/src/benchmark/capnpCarsales.ml
@@ -2,11 +2,9 @@
 module CS = Carsales.Make[@inlined](Capnp.BytesMessage)
 
 module TestCase = struct
-  type request_reader_t   = CS.Reader.ParkingLot.t
-  type request_builder_t  = CS.Builder.ParkingLot.t
-  type response_reader_t  = CS.Reader.TotalValue.t
-  type response_builder_t = CS.Builder.TotalValue.t
-  type expectation_t      = int
+  type request_t     = CS.Reader.ParkingLot.struct_t
+  type response_t    = CS.Reader.TotalValue.struct_t
+  type expectation_t = int
 
   let makes = [| "Toyota"; "GM"; "Ford"; "Honda"; "Tesla" |]
   let models = [| "Camry"; "Prius"; "Volt"; "Accord"; "Leaf"; "Model S" |]

--- a/src/benchmark/capnpCatrank.ml
+++ b/src/benchmark/capnpCatrank.ml
@@ -6,11 +6,9 @@ module CR = Catrank.Make[@inlined](Capnp.BytesMessage)
 open Core_kernel.Std
 
 module TestCase = struct
-  type request_reader_t   = CR.Reader.SearchResultList.t
-  type request_builder_t  = CR.Builder.SearchResultList.t
-  type response_reader_t  = CR.Reader.SearchResultList.t
-  type response_builder_t = CR.Builder.SearchResultList.t
-  type expectation_t      = int
+  type request_t     = CR.Reader.SearchResultList.struct_t
+  type response_t    = CR.Reader.SearchResultList.struct_t
+  type expectation_t = int
 
   let url_prefix = "http://example.com/"
   let url_prefix_len = String.length url_prefix

--- a/src/benchmark/capnpEval.ml
+++ b/src/benchmark/capnpEval.ml
@@ -4,11 +4,9 @@ module E = Eval.Make[@inlined](Capnp.BytesMessage)
 open Core_kernel.Std
 
 module TestCase = struct
-  type request_reader_t   = E.Reader.Expression.t
-  type request_builder_t  = E.Builder.Expression.t
-  type response_reader_t  = E.Reader.EvaluationResult.t
-  type response_builder_t = E.Builder.EvaluationResult.t
-  type expectation_t      = int
+  type request_t     = E.Reader.Expression.struct_t
+  type response_t    = E.Reader.EvaluationResult.struct_t
+  type expectation_t = int
 
   let operation_of_int v =
     match v with

--- a/src/benchmark/jbuild
+++ b/src/benchmark/jbuild
@@ -28,18 +28,18 @@ let config = {|
 
 (rule
  ((targets (carsales.ml carsales.mli))
-  (deps (carsales.capnp ../compiler/main.exe))
-  (action  (run capnpc -o ../compiler/main.exe ${<}))))
+  (deps (carsales.capnp ../compiler/main.bc))
+  (action  (run capnpc -o ../compiler/main.bc ${<}))))
 
 (rule
  ((targets (catrank.ml catrank.mli))
-  (deps (catrank.capnp ../compiler/main.exe))
-  (action  (run capnpc -o ../compiler/main.exe ${<}))))
+  (deps (catrank.capnp ../compiler/main.bc))
+  (action  (run capnpc -o ../compiler/main.bc ${<}))))
 
 (rule
  ((targets (eval.ml eval.mli))
-  (deps (eval.capnp ../compiler/main.exe))
-  (action  (run capnpc -o ../compiler/main.exe ${<}))))
+  (deps (eval.capnp ../compiler/main.bc))
+  (action  (run capnpc -o ../compiler/main.bc ${<}))))
 
 (alias
  ((name benchmarks)

--- a/src/benchmark/main.ml
+++ b/src/benchmark/main.ml
@@ -67,9 +67,7 @@ let () =
       let module BM = Methods.Benchmark
           (CapnpCarsales.TestCase)
           (CapnpCarsales.CS.Reader.ParkingLot)
-          (CapnpCarsales.CS.Builder.ParkingLot)
           (CapnpCarsales.CS.Reader.TotalValue)
-          (CapnpCarsales.CS.Builder.TotalValue)
       in
       let module BR = BenchmarkRunner(BM) in
       BR.f mode compression iters
@@ -81,9 +79,7 @@ let () =
       let module BM = Methods.Benchmark
           (CapnpCatrank.TestCase)
           (CapnpCatrank.CR.Reader.SearchResultList)
-          (CapnpCatrank.CR.Builder.SearchResultList)
           (CapnpCatrank.CR.Reader.SearchResultList)
-          (CapnpCatrank.CR.Builder.SearchResultList)
       in
       let module BR = BenchmarkRunner(BM) in
       BR.f mode compression iters
@@ -91,9 +87,7 @@ let () =
       let module BM = Methods.Benchmark
           (CapnpEval.TestCase)
           (CapnpEval.E.Reader.Expression)
-          (CapnpEval.E.Builder.Expression)
           (CapnpEval.E.Reader.EvaluationResult)
-          (CapnpEval.E.Builder.EvaluationResult)
       in
       let module BR = BenchmarkRunner(BM) in
       BR.f mode compression iters

--- a/src/benchmark/testCaseSig.ml
+++ b/src/benchmark/testCaseSig.ml
@@ -1,27 +1,16 @@
+open Capnp.BytesMessage.StructStorage
 
 module type TEST_CASE = sig
-  type request_reader_t
-  type request_builder_t
-  type response_reader_t
-  type response_builder_t
+  type request_t
+  type response_t
   type expectation_t
 
-  val setup_request : unit -> request_builder_t * expectation_t
-  val handle_request : request_reader_t -> response_builder_t
-  val check_response : response_reader_t -> expectation_t -> bool
+  val setup_request : unit -> request_t builder_t * expectation_t
+  val handle_request : request_t reader_t -> response_t builder_t
+  val check_response : response_t reader_t -> expectation_t -> bool
 end
 
 module type READER = sig
-  type t
-  type builder_t
-  val of_message : 'cap Capnp.BytesMessage.Message.t -> t
-  val of_builder : builder_t -> t
+  type struct_t
+  val of_message : 'cap Capnp.BytesMessage.Message.t -> struct_t reader_t
 end
-
-module type BUILDER = sig
-  type t
-  val to_message : t -> Capnp.Message.rw Capnp.BytesMessage.Message.t
-end
-
-
-

--- a/src/compiler/generate.ml
+++ b/src/compiler/generate.ml
@@ -206,23 +206,9 @@ let compile
     let context = GenCommon.filter_interesting_imports
         ~context:context_unfiltered requested_file_node
     in
-    let sig_unique_types = List.rev_map
-        (GenCommon.collect_unique_types ~context requested_file_node)
-        ~f:(function
-            | name, (`Hidden _ | `Abstract) -> "  type " ^ name
-            | name, `Public tp -> sprintf "  type %s = %s" name tp
-          )
-    in
     let sig_unique_enums =
       GenCommon.apply_indent ~indent:"  "
         (GenCommon.collect_unique_enums ~is_sig:true ~context requested_file_node)
-    in
-    let mod_unique_types = (List.rev_map
-        (GenCommon.collect_unique_types ~context requested_file_node)
-        ~f:(function
-            | name, (`Hidden tp | `Public tp) -> "  type " ^ name ^ " = " ^ tp
-            | name, `Abstract -> "  type " ^ name
-          )) @ [""]
     in
     let mod_unique_enums =
       GenCommon.apply_indent ~indent:"  "
@@ -230,7 +216,6 @@ let compile
     in
     let sig_s =
       (sig_s_header ~context) @
-      sig_unique_types @
       sig_unique_enums @
       sig_s_reader_header @
       (GenCommon.apply_indent ~indent:"    "
@@ -272,7 +257,6 @@ let compile
       in
       builder_defaults @
       (mod_header ~context) @
-      mod_unique_types @
       mod_unique_enums @
       reader_defaults @
       mod_reader_header @

--- a/src/compiler/pluginSchema.ml
+++ b/src/compiler/pluginSchema.ml
@@ -8,105 +8,6 @@ module type S = sig
   type 'a reader_t
   type 'a builder_t
 
-  type struct_Import_12560611460656617445
-  type reader_t_Import_12560611460656617445 = struct_Import_12560611460656617445 reader_t
-  type builder_t_Import_12560611460656617445 = struct_Import_12560611460656617445 builder_t
-  type struct_RequestedFile_14981803260258615394
-  type reader_t_RequestedFile_14981803260258615394 = struct_RequestedFile_14981803260258615394 reader_t
-  type builder_t_RequestedFile_14981803260258615394 = struct_RequestedFile_14981803260258615394 builder_t
-  type struct_CodeGeneratorRequest_13818529054586492878
-  type reader_t_CodeGeneratorRequest_13818529054586492878 = struct_CodeGeneratorRequest_13818529054586492878 reader_t
-  type builder_t_CodeGeneratorRequest_13818529054586492878 = struct_CodeGeneratorRequest_13818529054586492878 builder_t
-  type struct_CapnpVersion_15590670654532458851
-  type reader_t_CapnpVersion_15590670654532458851 = struct_CapnpVersion_15590670654532458851 reader_t
-  type builder_t_CapnpVersion_15590670654532458851 = struct_CapnpVersion_15590670654532458851 builder_t
-  type struct_Annotation_17422339044421236034
-  type reader_t_Annotation_17422339044421236034 = struct_Annotation_17422339044421236034 reader_t
-  type builder_t_Annotation_17422339044421236034 = struct_Annotation_17422339044421236034 builder_t
-  type struct_Value_14853958794117909659
-  type reader_t_Value_14853958794117909659 = struct_Value_14853958794117909659 reader_t
-  type builder_t_Value_14853958794117909659 = struct_Value_14853958794117909659 builder_t
-  type struct_Binding_14439610327179913212
-  type reader_t_Binding_14439610327179913212 = struct_Binding_14439610327179913212 reader_t
-  type builder_t_Binding_14439610327179913212 = struct_Binding_14439610327179913212 builder_t
-  type struct_Scope_12382423449155627977
-  type reader_t_Scope_12382423449155627977 = struct_Scope_12382423449155627977 reader_t
-  type builder_t_Scope_12382423449155627977 = struct_Scope_12382423449155627977 builder_t
-  type struct_Brand_10391024731148337707
-  type reader_t_Brand_10391024731148337707 = struct_Brand_10391024731148337707 reader_t
-  type builder_t_Brand_10391024731148337707 = struct_Brand_10391024731148337707 builder_t
-  type struct_ImplicitMethodParameter_13470206089842057844
-  type reader_t_ImplicitMethodParameter_13470206089842057844 = struct_ImplicitMethodParameter_13470206089842057844 reader_t
-  type builder_t_ImplicitMethodParameter_13470206089842057844 = struct_ImplicitMethodParameter_13470206089842057844 builder_t
-  type struct_Parameter_11372142272178113157
-  type reader_t_Parameter_11372142272178113157 = struct_Parameter_11372142272178113157 reader_t
-  type builder_t_Parameter_11372142272178113157 = struct_Parameter_11372142272178113157 builder_t
-  type struct_Unconstrained_10248890354574636630
-  type reader_t_Unconstrained_10248890354574636630 = struct_Unconstrained_10248890354574636630 reader_t
-  type builder_t_Unconstrained_10248890354574636630 = struct_Unconstrained_10248890354574636630 builder_t
-  type struct_AnyPointer_14003731834718800369
-  type reader_t_AnyPointer_14003731834718800369 = struct_AnyPointer_14003731834718800369 reader_t
-  type builder_t_AnyPointer_14003731834718800369 = struct_AnyPointer_14003731834718800369 builder_t
-  type struct_Interface_17116997365232503999
-  type reader_t_Interface_17116997365232503999 = struct_Interface_17116997365232503999 reader_t
-  type builder_t_Interface_17116997365232503999 = struct_Interface_17116997365232503999 builder_t
-  type struct_Struct_12410354185295152851
-  type reader_t_Struct_12410354185295152851 = struct_Struct_12410354185295152851 reader_t
-  type builder_t_Struct_12410354185295152851 = struct_Struct_12410354185295152851 builder_t
-  type struct_Enum_11389172934837766057
-  type reader_t_Enum_11389172934837766057 = struct_Enum_11389172934837766057 reader_t
-  type builder_t_Enum_11389172934837766057 = struct_Enum_11389172934837766057 builder_t
-  type struct_List_9792858745991129751
-  type reader_t_List_9792858745991129751 = struct_List_9792858745991129751 reader_t
-  type builder_t_List_9792858745991129751 = struct_List_9792858745991129751 builder_t
-  type struct_Type_15020482145304562784
-  type reader_t_Type_15020482145304562784 = struct_Type_15020482145304562784 reader_t
-  type builder_t_Type_15020482145304562784 = struct_Type_15020482145304562784 builder_t
-  type struct_Method_10736806783679155584
-  type reader_t_Method_10736806783679155584 = struct_Method_10736806783679155584 reader_t
-  type builder_t_Method_10736806783679155584 = struct_Method_10736806783679155584 builder_t
-  type struct_Superclass_12220001500510083064
-  type reader_t_Superclass_12220001500510083064 = struct_Superclass_12220001500510083064 reader_t
-  type builder_t_Superclass_12220001500510083064 = struct_Superclass_12220001500510083064 builder_t
-  type struct_Enumerant_10919677598968879693
-  type reader_t_Enumerant_10919677598968879693 = struct_Enumerant_10919677598968879693 reader_t
-  type builder_t_Enumerant_10919677598968879693 = struct_Enumerant_10919677598968879693 builder_t
-  type struct_Ordinal_13515537513213004774
-  type reader_t_Ordinal_13515537513213004774 = struct_Ordinal_13515537513213004774 reader_t
-  type builder_t_Ordinal_13515537513213004774 = struct_Ordinal_13515537513213004774 builder_t
-  type struct_Group_14626792032033250577
-  type reader_t_Group_14626792032033250577 = struct_Group_14626792032033250577 reader_t
-  type builder_t_Group_14626792032033250577 = struct_Group_14626792032033250577 builder_t
-  type struct_Slot_14133145859926553711
-  type reader_t_Slot_14133145859926553711 = struct_Slot_14133145859926553711 reader_t
-  type builder_t_Slot_14133145859926553711 = struct_Slot_14133145859926553711 builder_t
-  type struct_Field_11145653318641710175
-  type reader_t_Field_11145653318641710175 = struct_Field_11145653318641710175 reader_t
-  type builder_t_Field_11145653318641710175 = struct_Field_11145653318641710175 builder_t
-  type struct_NestedNode_16050641862814319170
-  type reader_t_NestedNode_16050641862814319170 = struct_NestedNode_16050641862814319170 reader_t
-  type builder_t_NestedNode_16050641862814319170 = struct_NestedNode_16050641862814319170 builder_t
-  type struct_Parameter_13353766412138554289
-  type reader_t_Parameter_13353766412138554289 = struct_Parameter_13353766412138554289 reader_t
-  type builder_t_Parameter_13353766412138554289 = struct_Parameter_13353766412138554289 builder_t
-  type struct_Annotation_17011813041836786320
-  type reader_t_Annotation_17011813041836786320 = struct_Annotation_17011813041836786320 reader_t
-  type builder_t_Annotation_17011813041836786320 = struct_Annotation_17011813041836786320 builder_t
-  type struct_Const_12793219851699983392
-  type reader_t_Const_12793219851699983392 = struct_Const_12793219851699983392 reader_t
-  type builder_t_Const_12793219851699983392 = struct_Const_12793219851699983392 builder_t
-  type struct_Interface_16728431493453586831
-  type reader_t_Interface_16728431493453586831 = struct_Interface_16728431493453586831 reader_t
-  type builder_t_Interface_16728431493453586831 = struct_Interface_16728431493453586831 builder_t
-  type struct_Enum_13063450714778629528
-  type reader_t_Enum_13063450714778629528 = struct_Enum_13063450714778629528 reader_t
-  type builder_t_Enum_13063450714778629528 = struct_Enum_13063450714778629528 builder_t
-  type struct_Struct_11430331134483579957
-  type reader_t_Struct_11430331134483579957 = struct_Struct_11430331134483579957 reader_t
-  type builder_t_Struct_11430331134483579957 = struct_Struct_11430331134483579957 builder_t
-  type struct_Node_16610026722781537303
-  type reader_t_Node_16610026722781537303 = struct_Node_16610026722781537303 reader_t
-  type builder_t_Node_16610026722781537303 = struct_Node_16610026722781537303 builder_t
   module ElementSize_15102134695616452902 : sig
     type t =
       | Empty
@@ -126,11 +27,11 @@ module type S = sig
     type pointer_t
     val of_pointer : pointer_t -> 'a reader_t
     module Node : sig
-      type t = reader_t_Node_16610026722781537303
-      type builder_t = builder_t_Node_16610026722781537303
+      type struct_t = [`Node_e682ab4cf923a417]
+      type t = struct_t reader_t
       module Struct : sig
-        type t = reader_t_Struct_11430331134483579957
-        type builder_t = builder_t_Struct_11430331134483579957
+        type struct_t = [`Struct_9ea0b19b37fb4435]
+        type t = struct_t reader_t
         val data_word_count_get : t -> int
         val pointer_count_get : t -> int
         val preferred_list_encoding_get : t -> ElementSize_15102134695616452902.t
@@ -139,51 +40,51 @@ module type S = sig
         val discriminant_offset_get : t -> Uint32.t
         val discriminant_offset_get_int_exn : t -> int
         val has_fields : t -> bool
-        val fields_get : t -> (ro, reader_t_Field_11145653318641710175, array_t) Capnp.Array.t
-        val fields_get_list : t -> reader_t_Field_11145653318641710175 list
-        val fields_get_array : t -> reader_t_Field_11145653318641710175 array
+        val fields_get : t -> (ro, [`Field_9aad50a41f4af45f] reader_t, array_t) Capnp.Array.t
+        val fields_get_list : t -> [`Field_9aad50a41f4af45f] reader_t list
+        val fields_get_array : t -> [`Field_9aad50a41f4af45f] reader_t array
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Enum : sig
-        type t = reader_t_Enum_13063450714778629528
-        type builder_t = builder_t_Enum_13063450714778629528
+        type struct_t = [`Enum_b54ab3364333f598]
+        type t = struct_t reader_t
         val has_enumerants : t -> bool
-        val enumerants_get : t -> (ro, reader_t_Enumerant_10919677598968879693, array_t) Capnp.Array.t
-        val enumerants_get_list : t -> reader_t_Enumerant_10919677598968879693 list
-        val enumerants_get_array : t -> reader_t_Enumerant_10919677598968879693 array
+        val enumerants_get : t -> (ro, [`Enumerant_978a7cebdc549a4d] reader_t, array_t) Capnp.Array.t
+        val enumerants_get_list : t -> [`Enumerant_978a7cebdc549a4d] reader_t list
+        val enumerants_get_array : t -> [`Enumerant_978a7cebdc549a4d] reader_t array
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Interface : sig
-        type t = reader_t_Interface_16728431493453586831
-        type builder_t = builder_t_Interface_16728431493453586831
+        type struct_t = [`Interface_e82753cff0c2218f]
+        type t = struct_t reader_t
         val has_methods : t -> bool
-        val methods_get : t -> (ro, reader_t_Method_10736806783679155584, array_t) Capnp.Array.t
-        val methods_get_list : t -> reader_t_Method_10736806783679155584 list
-        val methods_get_array : t -> reader_t_Method_10736806783679155584 array
+        val methods_get : t -> (ro, [`Method_9500cce23b334d80] reader_t, array_t) Capnp.Array.t
+        val methods_get_list : t -> [`Method_9500cce23b334d80] reader_t list
+        val methods_get_array : t -> [`Method_9500cce23b334d80] reader_t array
         val has_superclasses : t -> bool
-        val superclasses_get : t -> (ro, reader_t_Superclass_12220001500510083064, array_t) Capnp.Array.t
-        val superclasses_get_list : t -> reader_t_Superclass_12220001500510083064 list
-        val superclasses_get_array : t -> reader_t_Superclass_12220001500510083064 array
+        val superclasses_get : t -> (ro, [`Superclass_a9962a9ed0a4d7f8] reader_t, array_t) Capnp.Array.t
+        val superclasses_get_list : t -> [`Superclass_a9962a9ed0a4d7f8] reader_t list
+        val superclasses_get_array : t -> [`Superclass_a9962a9ed0a4d7f8] reader_t array
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Const : sig
-        type t = reader_t_Const_12793219851699983392
-        type builder_t = builder_t_Const_12793219851699983392
+        type struct_t = [`Const_b18aa5ac7a0d9420]
+        type t = struct_t reader_t
         val has_type : t -> bool
-        val type_get : t -> reader_t_Type_15020482145304562784
+        val type_get : t -> [`Type_d07378ede1f9cc60] reader_t
         val has_value : t -> bool
-        val value_get : t -> reader_t_Value_14853958794117909659
+        val value_get : t -> [`Value_ce23dcd2d7b00c9b] reader_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Annotation : sig
-        type t = reader_t_Annotation_17011813041836786320
-        type builder_t = builder_t_Annotation_17011813041836786320
+        type struct_t = [`Annotation_ec1619d4400a0290]
+        type t = struct_t reader_t
         val has_type : t -> bool
-        val type_get : t -> reader_t_Type_15020482145304562784
+        val type_get : t -> [`Type_d07378ede1f9cc60] reader_t
         val targets_file_get : t -> bool
         val targets_const_get : t -> bool
         val targets_enum_get : t -> bool
@@ -197,25 +98,25 @@ module type S = sig
         val targets_param_get : t -> bool
         val targets_annotation_get : t -> bool
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Parameter : sig
-        type t = reader_t_Parameter_13353766412138554289
-        type builder_t = builder_t_Parameter_13353766412138554289
+        type struct_t = [`Parameter_b9521bccf10fa3b1]
+        type t = struct_t reader_t
         val has_name : t -> bool
         val name_get : t -> string
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module NestedNode : sig
-        type t = reader_t_NestedNode_16050641862814319170
-        type builder_t = builder_t_NestedNode_16050641862814319170
+        type struct_t = [`NestedNode_debf55bbfa0fc242]
+        type t = struct_t reader_t
         val has_name : t -> bool
         val name_get : t -> string
         val id_get : t -> Uint64.t
         val id_get_int_exn : t -> int
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       type unnamed_union_t =
         | File
@@ -235,55 +136,55 @@ module type S = sig
       val scope_id_get : t -> Uint64.t
       val scope_id_get_int_exn : t -> int
       val has_parameters : t -> bool
-      val parameters_get : t -> (ro, reader_t_Parameter_13353766412138554289, array_t) Capnp.Array.t
-      val parameters_get_list : t -> reader_t_Parameter_13353766412138554289 list
-      val parameters_get_array : t -> reader_t_Parameter_13353766412138554289 array
+      val parameters_get : t -> (ro, [`Parameter_b9521bccf10fa3b1] reader_t, array_t) Capnp.Array.t
+      val parameters_get_list : t -> [`Parameter_b9521bccf10fa3b1] reader_t list
+      val parameters_get_array : t -> [`Parameter_b9521bccf10fa3b1] reader_t array
       val is_generic_get : t -> bool
       val has_nested_nodes : t -> bool
-      val nested_nodes_get : t -> (ro, reader_t_NestedNode_16050641862814319170, array_t) Capnp.Array.t
-      val nested_nodes_get_list : t -> reader_t_NestedNode_16050641862814319170 list
-      val nested_nodes_get_array : t -> reader_t_NestedNode_16050641862814319170 array
+      val nested_nodes_get : t -> (ro, [`NestedNode_debf55bbfa0fc242] reader_t, array_t) Capnp.Array.t
+      val nested_nodes_get_list : t -> [`NestedNode_debf55bbfa0fc242] reader_t list
+      val nested_nodes_get_array : t -> [`NestedNode_debf55bbfa0fc242] reader_t array
       val has_annotations : t -> bool
-      val annotations_get : t -> (ro, reader_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> reader_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> reader_t_Annotation_17422339044421236034 array
+      val annotations_get : t -> (ro, [`Annotation_f1c8950dab257542] reader_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] reader_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] reader_t array
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Field : sig
-      type t = reader_t_Field_11145653318641710175
-      type builder_t = builder_t_Field_11145653318641710175
+      type struct_t = [`Field_9aad50a41f4af45f]
+      type t = struct_t reader_t
       module Slot : sig
-        type t = reader_t_Slot_14133145859926553711
-        type builder_t = builder_t_Slot_14133145859926553711
+        type struct_t = [`Slot_c42305476bb4746f]
+        type t = struct_t reader_t
         val offset_get : t -> Uint32.t
         val offset_get_int_exn : t -> int
         val has_type : t -> bool
-        val type_get : t -> reader_t_Type_15020482145304562784
+        val type_get : t -> [`Type_d07378ede1f9cc60] reader_t
         val has_default_value : t -> bool
-        val default_value_get : t -> reader_t_Value_14853958794117909659
+        val default_value_get : t -> [`Value_ce23dcd2d7b00c9b] reader_t
         val had_explicit_default_get : t -> bool
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Group : sig
-        type t = reader_t_Group_14626792032033250577
-        type builder_t = builder_t_Group_14626792032033250577
+        type struct_t = [`Group_cafccddb68db1d11]
+        type t = struct_t reader_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Ordinal : sig
-        type t = reader_t_Ordinal_13515537513213004774
-        type builder_t = builder_t_Ordinal_13515537513213004774
+        type struct_t = [`Ordinal_bb90d5c287870be6]
+        type t = struct_t reader_t
         type unnamed_union_t =
           | Implicit
           | Explicit of int
           | Undefined of int
         val get : t -> unnamed_union_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       val no_discriminant : int
       type unnamed_union_t =
@@ -295,40 +196,40 @@ module type S = sig
       val name_get : t -> string
       val code_order_get : t -> int
       val has_annotations : t -> bool
-      val annotations_get : t -> (ro, reader_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> reader_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> reader_t_Annotation_17422339044421236034 array
+      val annotations_get : t -> (ro, [`Annotation_f1c8950dab257542] reader_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] reader_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] reader_t array
       val discriminant_value_get : t -> int
       val ordinal_get : t -> Ordinal.t
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Enumerant : sig
-      type t = reader_t_Enumerant_10919677598968879693
-      type builder_t = builder_t_Enumerant_10919677598968879693
+      type struct_t = [`Enumerant_978a7cebdc549a4d]
+      type t = struct_t reader_t
       val has_name : t -> bool
       val name_get : t -> string
       val code_order_get : t -> int
       val has_annotations : t -> bool
-      val annotations_get : t -> (ro, reader_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> reader_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> reader_t_Annotation_17422339044421236034 array
+      val annotations_get : t -> (ro, [`Annotation_f1c8950dab257542] reader_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] reader_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] reader_t array
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Superclass : sig
-      type t = reader_t_Superclass_12220001500510083064
-      type builder_t = builder_t_Superclass_12220001500510083064
+      type struct_t = [`Superclass_a9962a9ed0a4d7f8]
+      type t = struct_t reader_t
       val id_get : t -> Uint64.t
       val id_get_int_exn : t -> int
       val has_brand : t -> bool
-      val brand_get : t -> reader_t_Brand_10391024731148337707
+      val brand_get : t -> [`Brand_903455f06065422b] reader_t
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Method : sig
-      type t = reader_t_Method_10736806783679155584
-      type builder_t = builder_t_Method_10736806783679155584
+      type struct_t = [`Method_9500cce23b334d80]
+      type t = struct_t reader_t
       val has_name : t -> bool
       val name_get : t -> string
       val code_order_get : t -> int
@@ -339,65 +240,65 @@ module type S = sig
       val param_struct_type_get : t -> Uint64.t
       val param_struct_type_get_int_exn : t -> int
       val has_param_brand : t -> bool
-      val param_brand_get : t -> reader_t_Brand_10391024731148337707
+      val param_brand_get : t -> [`Brand_903455f06065422b] reader_t
       val result_struct_type_get : t -> Uint64.t
       val result_struct_type_get_int_exn : t -> int
       val has_result_brand : t -> bool
-      val result_brand_get : t -> reader_t_Brand_10391024731148337707
+      val result_brand_get : t -> [`Brand_903455f06065422b] reader_t
       val has_annotations : t -> bool
-      val annotations_get : t -> (ro, reader_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> reader_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> reader_t_Annotation_17422339044421236034 array
+      val annotations_get : t -> (ro, [`Annotation_f1c8950dab257542] reader_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] reader_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] reader_t array
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Type : sig
-      type t = reader_t_Type_15020482145304562784
-      type builder_t = builder_t_Type_15020482145304562784
+      type struct_t = [`Type_d07378ede1f9cc60]
+      type t = struct_t reader_t
       module List : sig
-        type t = reader_t_List_9792858745991129751
-        type builder_t = builder_t_List_9792858745991129751
+        type struct_t = [`List_87e739250a60ea97]
+        type t = struct_t reader_t
         val has_element_type : t -> bool
-        val element_type_get : t -> reader_t_Type_15020482145304562784
+        val element_type_get : t -> [`Type_d07378ede1f9cc60] reader_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Enum : sig
-        type t = reader_t_Enum_11389172934837766057
-        type builder_t = builder_t_Enum_11389172934837766057
+        type struct_t = [`Enum_9e0e78711a7f87a9]
+        type t = struct_t reader_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val has_brand : t -> bool
-        val brand_get : t -> reader_t_Brand_10391024731148337707
+        val brand_get : t -> [`Brand_903455f06065422b] reader_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Struct : sig
-        type t = reader_t_Struct_12410354185295152851
-        type builder_t = builder_t_Struct_12410354185295152851
+        type struct_t = [`Struct_ac3a6f60ef4cc6d3]
+        type t = struct_t reader_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val has_brand : t -> bool
-        val brand_get : t -> reader_t_Brand_10391024731148337707
+        val brand_get : t -> [`Brand_903455f06065422b] reader_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Interface : sig
-        type t = reader_t_Interface_17116997365232503999
-        type builder_t = builder_t_Interface_17116997365232503999
+        type struct_t = [`Interface_ed8bca69f7fb0cbf]
+        type t = struct_t reader_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val has_brand : t -> bool
-        val brand_get : t -> reader_t_Brand_10391024731148337707
+        val brand_get : t -> [`Brand_903455f06065422b] reader_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module AnyPointer : sig
-        type t = reader_t_AnyPointer_14003731834718800369
-        type builder_t = builder_t_AnyPointer_14003731834718800369
+        type struct_t = [`AnyPointer_c2573fe8a23e49f1]
+        type t = struct_t reader_t
         module Unconstrained : sig
-          type t = reader_t_Unconstrained_10248890354574636630
-          type builder_t = builder_t_Unconstrained_10248890354574636630
+          type struct_t = [`Unconstrained_8e3b5f79fe593656]
+          type t = struct_t reader_t
           type unnamed_union_t =
             | AnyKind
             | Struct
@@ -406,23 +307,23 @@ module type S = sig
             | Undefined of int
           val get : t -> unnamed_union_t
           val of_message : 'cap message_t -> t
-          val of_builder : builder_t -> t
+          val of_builder : struct_t builder_t -> t
         end
         module Parameter : sig
-          type t = reader_t_Parameter_11372142272178113157
-          type builder_t = builder_t_Parameter_11372142272178113157
+          type struct_t = [`Parameter_9dd1f724f4614a85]
+          type t = struct_t reader_t
           val scope_id_get : t -> Uint64.t
           val scope_id_get_int_exn : t -> int
           val parameter_index_get : t -> int
           val of_message : 'cap message_t -> t
-          val of_builder : builder_t -> t
+          val of_builder : struct_t builder_t -> t
         end
         module ImplicitMethodParameter : sig
-          type t = reader_t_ImplicitMethodParameter_13470206089842057844
-          type builder_t = builder_t_ImplicitMethodParameter_13470206089842057844
+          type struct_t = [`ImplicitMethodParameter_baefc9120c56e274]
+          type t = struct_t reader_t
           val parameter_index_get : t -> int
           val of_message : 'cap message_t -> t
-          val of_builder : builder_t -> t
+          val of_builder : struct_t builder_t -> t
         end
         type unnamed_union_t =
           | Unconstrained of Unconstrained.t
@@ -431,7 +332,7 @@ module type S = sig
           | Undefined of int
         val get : t -> unnamed_union_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       type unnamed_union_t =
         | Void
@@ -456,45 +357,45 @@ module type S = sig
         | Undefined of int
       val get : t -> unnamed_union_t
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Brand : sig
-      type t = reader_t_Brand_10391024731148337707
-      type builder_t = builder_t_Brand_10391024731148337707
+      type struct_t = [`Brand_903455f06065422b]
+      type t = struct_t reader_t
       module Scope : sig
-        type t = reader_t_Scope_12382423449155627977
-        type builder_t = builder_t_Scope_12382423449155627977
+        type struct_t = [`Scope_abd73485a9636bc9]
+        type t = struct_t reader_t
         type unnamed_union_t =
-          | Bind of (ro, reader_t_Binding_14439610327179913212, array_t) Capnp.Array.t
+          | Bind of (ro, [`Binding_c863cd16969ee7fc] reader_t, array_t) Capnp.Array.t
           | Inherit
           | Undefined of int
         val get : t -> unnamed_union_t
         val scope_id_get : t -> Uint64.t
         val scope_id_get_int_exn : t -> int
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Binding : sig
-        type t = reader_t_Binding_14439610327179913212
-        type builder_t = builder_t_Binding_14439610327179913212
+        type struct_t = [`Binding_c863cd16969ee7fc]
+        type t = struct_t reader_t
         type unnamed_union_t =
           | Unbound
           | Type of Type.t
           | Undefined of int
         val get : t -> unnamed_union_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       val has_scopes : t -> bool
-      val scopes_get : t -> (ro, reader_t_Scope_12382423449155627977, array_t) Capnp.Array.t
-      val scopes_get_list : t -> reader_t_Scope_12382423449155627977 list
-      val scopes_get_array : t -> reader_t_Scope_12382423449155627977 array
+      val scopes_get : t -> (ro, [`Scope_abd73485a9636bc9] reader_t, array_t) Capnp.Array.t
+      val scopes_get_list : t -> [`Scope_abd73485a9636bc9] reader_t list
+      val scopes_get_array : t -> [`Scope_abd73485a9636bc9] reader_t array
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Value : sig
-      type t = reader_t_Value_14853958794117909659
-      type builder_t = builder_t_Value_14853958794117909659
+      type struct_t = [`Value_ce23dcd2d7b00c9b]
+      type t = struct_t reader_t
       type unnamed_union_t =
         | Void
         | Bool of bool
@@ -518,11 +419,11 @@ module type S = sig
         | Undefined of int
       val get : t -> unnamed_union_t
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Annotation : sig
-      type t = reader_t_Annotation_17422339044421236034
-      type builder_t = builder_t_Annotation_17422339044421236034
+      type struct_t = [`Annotation_f1c8950dab257542]
+      type t = struct_t reader_t
       val id_get : t -> Uint64.t
       val id_get_int_exn : t -> int
       val has_brand : t -> bool
@@ -530,7 +431,7 @@ module type S = sig
       val has_value : t -> bool
       val value_get : t -> Value.t
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module ElementSize : sig
       type t = ElementSize_15102134695616452902.t =
@@ -545,40 +446,40 @@ module type S = sig
         | Undefined of int
     end
     module CapnpVersion : sig
-      type t = reader_t_CapnpVersion_15590670654532458851
-      type builder_t = builder_t_CapnpVersion_15590670654532458851
+      type struct_t = [`CapnpVersion_d85d305b7d839963]
+      type t = struct_t reader_t
       val major_get : t -> int
       val minor_get : t -> int
       val micro_get : t -> int
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module CodeGeneratorRequest : sig
-      type t = reader_t_CodeGeneratorRequest_13818529054586492878
-      type builder_t = builder_t_CodeGeneratorRequest_13818529054586492878
+      type struct_t = [`CodeGeneratorRequest_bfc546f6210ad7ce]
+      type t = struct_t reader_t
       module RequestedFile : sig
-        type t = reader_t_RequestedFile_14981803260258615394
-        type builder_t = builder_t_RequestedFile_14981803260258615394
+        type struct_t = [`RequestedFile_cfea0eb02e810062]
+        type t = struct_t reader_t
         module Import : sig
-          type t = reader_t_Import_12560611460656617445
-          type builder_t = builder_t_Import_12560611460656617445
+          type struct_t = [`Import_ae504193122357e5]
+          type t = struct_t reader_t
           val id_get : t -> Uint64.t
           val id_get_int_exn : t -> int
           val has_name : t -> bool
           val name_get : t -> string
           val of_message : 'cap message_t -> t
-          val of_builder : builder_t -> t
+          val of_builder : struct_t builder_t -> t
         end
         val id_get : t -> Uint64.t
         val id_get_int_exn : t -> int
         val has_filename : t -> bool
         val filename_get : t -> string
         val has_imports : t -> bool
-        val imports_get : t -> (ro, reader_t_Import_12560611460656617445, array_t) Capnp.Array.t
-        val imports_get_list : t -> reader_t_Import_12560611460656617445 list
-        val imports_get_array : t -> reader_t_Import_12560611460656617445 array
+        val imports_get : t -> (ro, [`Import_ae504193122357e5] reader_t, array_t) Capnp.Array.t
+        val imports_get_list : t -> [`Import_ae504193122357e5] reader_t list
+        val imports_get_array : t -> [`Import_ae504193122357e5] reader_t array
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       val has_capnp_version : t -> bool
       val capnp_version_get : t -> CapnpVersion.t
@@ -587,11 +488,11 @@ module type S = sig
       val nodes_get_list : t -> Node.t list
       val nodes_get_array : t -> Node.t array
       val has_requested_files : t -> bool
-      val requested_files_get : t -> (ro, reader_t_RequestedFile_14981803260258615394, array_t) Capnp.Array.t
-      val requested_files_get_list : t -> reader_t_RequestedFile_14981803260258615394 list
-      val requested_files_get_array : t -> reader_t_RequestedFile_14981803260258615394 array
+      val requested_files_get : t -> (ro, [`RequestedFile_cfea0eb02e810062] reader_t, array_t) Capnp.Array.t
+      val requested_files_get_list : t -> [`RequestedFile_cfea0eb02e810062] reader_t list
+      val requested_files_get_array : t -> [`RequestedFile_cfea0eb02e810062] reader_t array
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
   end
 
@@ -600,11 +501,11 @@ module type S = sig
     type reader_array_t = Reader.array_t
     type pointer_t
     module Node : sig
-      type t = builder_t_Node_16610026722781537303
-      type reader_t = reader_t_Node_16610026722781537303
+      type struct_t = [`Node_e682ab4cf923a417]
+      type t = struct_t builder_t
       module Struct : sig
-        type t = builder_t_Struct_11430331134483579957
-        type reader_t = reader_t_Struct_11430331134483579957
+        type struct_t = [`Struct_9ea0b19b37fb4435]
+        type t = struct_t builder_t
         val data_word_count_get : t -> int
         val data_word_count_set_exn : t -> int -> unit
         val pointer_count_get : t -> int
@@ -621,88 +522,88 @@ module type S = sig
         val discriminant_offset_set : t -> Uint32.t -> unit
         val discriminant_offset_set_int_exn : t -> int -> unit
         val has_fields : t -> bool
-        val fields_get : t -> (rw, builder_t_Field_11145653318641710175, array_t) Capnp.Array.t
-        val fields_get_list : t -> builder_t_Field_11145653318641710175 list
-        val fields_get_array : t -> builder_t_Field_11145653318641710175 array
-        val fields_set : t -> (rw, builder_t_Field_11145653318641710175, array_t) Capnp.Array.t -> (rw, builder_t_Field_11145653318641710175, array_t) Capnp.Array.t
-        val fields_set_list : t -> builder_t_Field_11145653318641710175 list -> (rw, builder_t_Field_11145653318641710175, array_t) Capnp.Array.t
-        val fields_set_array : t -> builder_t_Field_11145653318641710175 array -> (rw, builder_t_Field_11145653318641710175, array_t) Capnp.Array.t
-        val fields_init : t -> int -> (rw, builder_t_Field_11145653318641710175, array_t) Capnp.Array.t
+        val fields_get : t -> (rw, [`Field_9aad50a41f4af45f] builder_t, array_t) Capnp.Array.t
+        val fields_get_list : t -> [`Field_9aad50a41f4af45f] builder_t list
+        val fields_get_array : t -> [`Field_9aad50a41f4af45f] builder_t array
+        val fields_set : t -> (rw, [`Field_9aad50a41f4af45f] builder_t, array_t) Capnp.Array.t -> (rw, [`Field_9aad50a41f4af45f] builder_t, array_t) Capnp.Array.t
+        val fields_set_list : t -> [`Field_9aad50a41f4af45f] builder_t list -> (rw, [`Field_9aad50a41f4af45f] builder_t, array_t) Capnp.Array.t
+        val fields_set_array : t -> [`Field_9aad50a41f4af45f] builder_t array -> (rw, [`Field_9aad50a41f4af45f] builder_t, array_t) Capnp.Array.t
+        val fields_init : t -> int -> (rw, [`Field_9aad50a41f4af45f] builder_t, array_t) Capnp.Array.t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Enum : sig
-        type t = builder_t_Enum_13063450714778629528
-        type reader_t = reader_t_Enum_13063450714778629528
+        type struct_t = [`Enum_b54ab3364333f598]
+        type t = struct_t builder_t
         val has_enumerants : t -> bool
-        val enumerants_get : t -> (rw, builder_t_Enumerant_10919677598968879693, array_t) Capnp.Array.t
-        val enumerants_get_list : t -> builder_t_Enumerant_10919677598968879693 list
-        val enumerants_get_array : t -> builder_t_Enumerant_10919677598968879693 array
-        val enumerants_set : t -> (rw, builder_t_Enumerant_10919677598968879693, array_t) Capnp.Array.t -> (rw, builder_t_Enumerant_10919677598968879693, array_t) Capnp.Array.t
-        val enumerants_set_list : t -> builder_t_Enumerant_10919677598968879693 list -> (rw, builder_t_Enumerant_10919677598968879693, array_t) Capnp.Array.t
-        val enumerants_set_array : t -> builder_t_Enumerant_10919677598968879693 array -> (rw, builder_t_Enumerant_10919677598968879693, array_t) Capnp.Array.t
-        val enumerants_init : t -> int -> (rw, builder_t_Enumerant_10919677598968879693, array_t) Capnp.Array.t
+        val enumerants_get : t -> (rw, [`Enumerant_978a7cebdc549a4d] builder_t, array_t) Capnp.Array.t
+        val enumerants_get_list : t -> [`Enumerant_978a7cebdc549a4d] builder_t list
+        val enumerants_get_array : t -> [`Enumerant_978a7cebdc549a4d] builder_t array
+        val enumerants_set : t -> (rw, [`Enumerant_978a7cebdc549a4d] builder_t, array_t) Capnp.Array.t -> (rw, [`Enumerant_978a7cebdc549a4d] builder_t, array_t) Capnp.Array.t
+        val enumerants_set_list : t -> [`Enumerant_978a7cebdc549a4d] builder_t list -> (rw, [`Enumerant_978a7cebdc549a4d] builder_t, array_t) Capnp.Array.t
+        val enumerants_set_array : t -> [`Enumerant_978a7cebdc549a4d] builder_t array -> (rw, [`Enumerant_978a7cebdc549a4d] builder_t, array_t) Capnp.Array.t
+        val enumerants_init : t -> int -> (rw, [`Enumerant_978a7cebdc549a4d] builder_t, array_t) Capnp.Array.t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Interface : sig
-        type t = builder_t_Interface_16728431493453586831
-        type reader_t = reader_t_Interface_16728431493453586831
+        type struct_t = [`Interface_e82753cff0c2218f]
+        type t = struct_t builder_t
         val has_methods : t -> bool
-        val methods_get : t -> (rw, builder_t_Method_10736806783679155584, array_t) Capnp.Array.t
-        val methods_get_list : t -> builder_t_Method_10736806783679155584 list
-        val methods_get_array : t -> builder_t_Method_10736806783679155584 array
-        val methods_set : t -> (rw, builder_t_Method_10736806783679155584, array_t) Capnp.Array.t -> (rw, builder_t_Method_10736806783679155584, array_t) Capnp.Array.t
-        val methods_set_list : t -> builder_t_Method_10736806783679155584 list -> (rw, builder_t_Method_10736806783679155584, array_t) Capnp.Array.t
-        val methods_set_array : t -> builder_t_Method_10736806783679155584 array -> (rw, builder_t_Method_10736806783679155584, array_t) Capnp.Array.t
-        val methods_init : t -> int -> (rw, builder_t_Method_10736806783679155584, array_t) Capnp.Array.t
+        val methods_get : t -> (rw, [`Method_9500cce23b334d80] builder_t, array_t) Capnp.Array.t
+        val methods_get_list : t -> [`Method_9500cce23b334d80] builder_t list
+        val methods_get_array : t -> [`Method_9500cce23b334d80] builder_t array
+        val methods_set : t -> (rw, [`Method_9500cce23b334d80] builder_t, array_t) Capnp.Array.t -> (rw, [`Method_9500cce23b334d80] builder_t, array_t) Capnp.Array.t
+        val methods_set_list : t -> [`Method_9500cce23b334d80] builder_t list -> (rw, [`Method_9500cce23b334d80] builder_t, array_t) Capnp.Array.t
+        val methods_set_array : t -> [`Method_9500cce23b334d80] builder_t array -> (rw, [`Method_9500cce23b334d80] builder_t, array_t) Capnp.Array.t
+        val methods_init : t -> int -> (rw, [`Method_9500cce23b334d80] builder_t, array_t) Capnp.Array.t
         val has_superclasses : t -> bool
-        val superclasses_get : t -> (rw, builder_t_Superclass_12220001500510083064, array_t) Capnp.Array.t
-        val superclasses_get_list : t -> builder_t_Superclass_12220001500510083064 list
-        val superclasses_get_array : t -> builder_t_Superclass_12220001500510083064 array
-        val superclasses_set : t -> (rw, builder_t_Superclass_12220001500510083064, array_t) Capnp.Array.t -> (rw, builder_t_Superclass_12220001500510083064, array_t) Capnp.Array.t
-        val superclasses_set_list : t -> builder_t_Superclass_12220001500510083064 list -> (rw, builder_t_Superclass_12220001500510083064, array_t) Capnp.Array.t
-        val superclasses_set_array : t -> builder_t_Superclass_12220001500510083064 array -> (rw, builder_t_Superclass_12220001500510083064, array_t) Capnp.Array.t
-        val superclasses_init : t -> int -> (rw, builder_t_Superclass_12220001500510083064, array_t) Capnp.Array.t
+        val superclasses_get : t -> (rw, [`Superclass_a9962a9ed0a4d7f8] builder_t, array_t) Capnp.Array.t
+        val superclasses_get_list : t -> [`Superclass_a9962a9ed0a4d7f8] builder_t list
+        val superclasses_get_array : t -> [`Superclass_a9962a9ed0a4d7f8] builder_t array
+        val superclasses_set : t -> (rw, [`Superclass_a9962a9ed0a4d7f8] builder_t, array_t) Capnp.Array.t -> (rw, [`Superclass_a9962a9ed0a4d7f8] builder_t, array_t) Capnp.Array.t
+        val superclasses_set_list : t -> [`Superclass_a9962a9ed0a4d7f8] builder_t list -> (rw, [`Superclass_a9962a9ed0a4d7f8] builder_t, array_t) Capnp.Array.t
+        val superclasses_set_array : t -> [`Superclass_a9962a9ed0a4d7f8] builder_t array -> (rw, [`Superclass_a9962a9ed0a4d7f8] builder_t, array_t) Capnp.Array.t
+        val superclasses_init : t -> int -> (rw, [`Superclass_a9962a9ed0a4d7f8] builder_t, array_t) Capnp.Array.t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Const : sig
-        type t = builder_t_Const_12793219851699983392
-        type reader_t = reader_t_Const_12793219851699983392
+        type struct_t = [`Const_b18aa5ac7a0d9420]
+        type t = struct_t builder_t
         val has_type : t -> bool
-        val type_get : t -> builder_t_Type_15020482145304562784
-        val type_set_reader : t -> reader_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val type_set_builder : t -> builder_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val type_init : t -> builder_t_Type_15020482145304562784
+        val type_get : t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_set_reader : t -> [`Type_d07378ede1f9cc60] reader_t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_set_builder : t -> [`Type_d07378ede1f9cc60] builder_t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_init : t -> [`Type_d07378ede1f9cc60] builder_t
         val has_value : t -> bool
-        val value_get : t -> builder_t_Value_14853958794117909659
-        val value_set_reader : t -> reader_t_Value_14853958794117909659 -> builder_t_Value_14853958794117909659
-        val value_set_builder : t -> builder_t_Value_14853958794117909659 -> builder_t_Value_14853958794117909659
-        val value_init : t -> builder_t_Value_14853958794117909659
+        val value_get : t -> [`Value_ce23dcd2d7b00c9b] builder_t
+        val value_set_reader : t -> [`Value_ce23dcd2d7b00c9b] reader_t -> [`Value_ce23dcd2d7b00c9b] builder_t
+        val value_set_builder : t -> [`Value_ce23dcd2d7b00c9b] builder_t -> [`Value_ce23dcd2d7b00c9b] builder_t
+        val value_init : t -> [`Value_ce23dcd2d7b00c9b] builder_t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Annotation : sig
-        type t = builder_t_Annotation_17011813041836786320
-        type reader_t = reader_t_Annotation_17011813041836786320
+        type struct_t = [`Annotation_ec1619d4400a0290]
+        type t = struct_t builder_t
         val has_type : t -> bool
-        val type_get : t -> builder_t_Type_15020482145304562784
-        val type_set_reader : t -> reader_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val type_set_builder : t -> builder_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val type_init : t -> builder_t_Type_15020482145304562784
+        val type_get : t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_set_reader : t -> [`Type_d07378ede1f9cc60] reader_t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_set_builder : t -> [`Type_d07378ede1f9cc60] builder_t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_init : t -> [`Type_d07378ede1f9cc60] builder_t
         val targets_file_get : t -> bool
         val targets_file_set : t -> bool -> unit
         val targets_const_get : t -> bool
@@ -729,25 +630,25 @@ module type S = sig
         val targets_annotation_set : t -> bool -> unit
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Parameter : sig
-        type t = builder_t_Parameter_13353766412138554289
-        type reader_t = reader_t_Parameter_13353766412138554289
+        type struct_t = [`Parameter_b9521bccf10fa3b1]
+        type t = struct_t builder_t
         val has_name : t -> bool
         val name_get : t -> string
         val name_set : t -> string -> unit
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module NestedNode : sig
-        type t = builder_t_NestedNode_16050641862814319170
-        type reader_t = reader_t_NestedNode_16050641862814319170
+        type struct_t = [`NestedNode_debf55bbfa0fc242]
+        type t = struct_t builder_t
         val has_name : t -> bool
         val name_get : t -> string
         val name_set : t -> string -> unit
@@ -757,7 +658,7 @@ module type S = sig
         val id_set_int_exn : t -> int -> unit
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
@@ -792,81 +693,81 @@ module type S = sig
       val scope_id_set : t -> Uint64.t -> unit
       val scope_id_set_int_exn : t -> int -> unit
       val has_parameters : t -> bool
-      val parameters_get : t -> (rw, builder_t_Parameter_13353766412138554289, array_t) Capnp.Array.t
-      val parameters_get_list : t -> builder_t_Parameter_13353766412138554289 list
-      val parameters_get_array : t -> builder_t_Parameter_13353766412138554289 array
-      val parameters_set : t -> (rw, builder_t_Parameter_13353766412138554289, array_t) Capnp.Array.t -> (rw, builder_t_Parameter_13353766412138554289, array_t) Capnp.Array.t
-      val parameters_set_list : t -> builder_t_Parameter_13353766412138554289 list -> (rw, builder_t_Parameter_13353766412138554289, array_t) Capnp.Array.t
-      val parameters_set_array : t -> builder_t_Parameter_13353766412138554289 array -> (rw, builder_t_Parameter_13353766412138554289, array_t) Capnp.Array.t
-      val parameters_init : t -> int -> (rw, builder_t_Parameter_13353766412138554289, array_t) Capnp.Array.t
+      val parameters_get : t -> (rw, [`Parameter_b9521bccf10fa3b1] builder_t, array_t) Capnp.Array.t
+      val parameters_get_list : t -> [`Parameter_b9521bccf10fa3b1] builder_t list
+      val parameters_get_array : t -> [`Parameter_b9521bccf10fa3b1] builder_t array
+      val parameters_set : t -> (rw, [`Parameter_b9521bccf10fa3b1] builder_t, array_t) Capnp.Array.t -> (rw, [`Parameter_b9521bccf10fa3b1] builder_t, array_t) Capnp.Array.t
+      val parameters_set_list : t -> [`Parameter_b9521bccf10fa3b1] builder_t list -> (rw, [`Parameter_b9521bccf10fa3b1] builder_t, array_t) Capnp.Array.t
+      val parameters_set_array : t -> [`Parameter_b9521bccf10fa3b1] builder_t array -> (rw, [`Parameter_b9521bccf10fa3b1] builder_t, array_t) Capnp.Array.t
+      val parameters_init : t -> int -> (rw, [`Parameter_b9521bccf10fa3b1] builder_t, array_t) Capnp.Array.t
       val is_generic_get : t -> bool
       val is_generic_set : t -> bool -> unit
       val has_nested_nodes : t -> bool
-      val nested_nodes_get : t -> (rw, builder_t_NestedNode_16050641862814319170, array_t) Capnp.Array.t
-      val nested_nodes_get_list : t -> builder_t_NestedNode_16050641862814319170 list
-      val nested_nodes_get_array : t -> builder_t_NestedNode_16050641862814319170 array
-      val nested_nodes_set : t -> (rw, builder_t_NestedNode_16050641862814319170, array_t) Capnp.Array.t -> (rw, builder_t_NestedNode_16050641862814319170, array_t) Capnp.Array.t
-      val nested_nodes_set_list : t -> builder_t_NestedNode_16050641862814319170 list -> (rw, builder_t_NestedNode_16050641862814319170, array_t) Capnp.Array.t
-      val nested_nodes_set_array : t -> builder_t_NestedNode_16050641862814319170 array -> (rw, builder_t_NestedNode_16050641862814319170, array_t) Capnp.Array.t
-      val nested_nodes_init : t -> int -> (rw, builder_t_NestedNode_16050641862814319170, array_t) Capnp.Array.t
+      val nested_nodes_get : t -> (rw, [`NestedNode_debf55bbfa0fc242] builder_t, array_t) Capnp.Array.t
+      val nested_nodes_get_list : t -> [`NestedNode_debf55bbfa0fc242] builder_t list
+      val nested_nodes_get_array : t -> [`NestedNode_debf55bbfa0fc242] builder_t array
+      val nested_nodes_set : t -> (rw, [`NestedNode_debf55bbfa0fc242] builder_t, array_t) Capnp.Array.t -> (rw, [`NestedNode_debf55bbfa0fc242] builder_t, array_t) Capnp.Array.t
+      val nested_nodes_set_list : t -> [`NestedNode_debf55bbfa0fc242] builder_t list -> (rw, [`NestedNode_debf55bbfa0fc242] builder_t, array_t) Capnp.Array.t
+      val nested_nodes_set_array : t -> [`NestedNode_debf55bbfa0fc242] builder_t array -> (rw, [`NestedNode_debf55bbfa0fc242] builder_t, array_t) Capnp.Array.t
+      val nested_nodes_init : t -> int -> (rw, [`NestedNode_debf55bbfa0fc242] builder_t, array_t) Capnp.Array.t
       val has_annotations : t -> bool
-      val annotations_get : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> builder_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> builder_t_Annotation_17422339044421236034 array
-      val annotations_set : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_list : t -> builder_t_Annotation_17422339044421236034 list -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_array : t -> builder_t_Annotation_17422339044421236034 array -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_init : t -> int -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
+      val annotations_get : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] builder_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] builder_t array
+      val annotations_set : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_list : t -> [`Annotation_f1c8950dab257542] builder_t list -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_array : t -> [`Annotation_f1c8950dab257542] builder_t array -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_init : t -> int -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Field : sig
-      type t = builder_t_Field_11145653318641710175
-      type reader_t = reader_t_Field_11145653318641710175
+      type struct_t = [`Field_9aad50a41f4af45f]
+      type t = struct_t builder_t
       module Slot : sig
-        type t = builder_t_Slot_14133145859926553711
-        type reader_t = reader_t_Slot_14133145859926553711
+        type struct_t = [`Slot_c42305476bb4746f]
+        type t = struct_t builder_t
         val offset_get : t -> Uint32.t
         val offset_get_int_exn : t -> int
         val offset_set : t -> Uint32.t -> unit
         val offset_set_int_exn : t -> int -> unit
         val has_type : t -> bool
-        val type_get : t -> builder_t_Type_15020482145304562784
-        val type_set_reader : t -> reader_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val type_set_builder : t -> builder_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val type_init : t -> builder_t_Type_15020482145304562784
+        val type_get : t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_set_reader : t -> [`Type_d07378ede1f9cc60] reader_t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_set_builder : t -> [`Type_d07378ede1f9cc60] builder_t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_init : t -> [`Type_d07378ede1f9cc60] builder_t
         val has_default_value : t -> bool
-        val default_value_get : t -> builder_t_Value_14853958794117909659
-        val default_value_set_reader : t -> reader_t_Value_14853958794117909659 -> builder_t_Value_14853958794117909659
-        val default_value_set_builder : t -> builder_t_Value_14853958794117909659 -> builder_t_Value_14853958794117909659
-        val default_value_init : t -> builder_t_Value_14853958794117909659
+        val default_value_get : t -> [`Value_ce23dcd2d7b00c9b] builder_t
+        val default_value_set_reader : t -> [`Value_ce23dcd2d7b00c9b] reader_t -> [`Value_ce23dcd2d7b00c9b] builder_t
+        val default_value_set_builder : t -> [`Value_ce23dcd2d7b00c9b] builder_t -> [`Value_ce23dcd2d7b00c9b] builder_t
+        val default_value_init : t -> [`Value_ce23dcd2d7b00c9b] builder_t
         val had_explicit_default_get : t -> bool
         val had_explicit_default_set : t -> bool -> unit
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Group : sig
-        type t = builder_t_Group_14626792032033250577
-        type reader_t = reader_t_Group_14626792032033250577
+        type struct_t = [`Group_cafccddb68db1d11]
+        type t = struct_t builder_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val type_id_set : t -> Uint64.t -> unit
         val type_id_set_int_exn : t -> int -> unit
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Ordinal : sig
-        type t = builder_t_Ordinal_13515537513213004774
-        type reader_t = reader_t_Ordinal_13515537513213004774
+        type struct_t = [`Ordinal_bb90d5c287870be6]
+        type t = struct_t builder_t
         type unnamed_union_t =
           | Implicit
           | Explicit of int
@@ -876,7 +777,7 @@ module type S = sig
         val explicit_set_exn : t -> int -> unit
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
@@ -894,66 +795,66 @@ module type S = sig
       val code_order_get : t -> int
       val code_order_set_exn : t -> int -> unit
       val has_annotations : t -> bool
-      val annotations_get : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> builder_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> builder_t_Annotation_17422339044421236034 array
-      val annotations_set : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_list : t -> builder_t_Annotation_17422339044421236034 list -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_array : t -> builder_t_Annotation_17422339044421236034 array -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_init : t -> int -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
+      val annotations_get : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] builder_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] builder_t array
+      val annotations_set : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_list : t -> [`Annotation_f1c8950dab257542] builder_t list -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_array : t -> [`Annotation_f1c8950dab257542] builder_t array -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_init : t -> int -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
       val discriminant_value_get : t -> int
       val discriminant_value_set_exn : t -> int -> unit
       val ordinal_get : t -> Ordinal.t
       val ordinal_init : t -> Ordinal.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Enumerant : sig
-      type t = builder_t_Enumerant_10919677598968879693
-      type reader_t = reader_t_Enumerant_10919677598968879693
+      type struct_t = [`Enumerant_978a7cebdc549a4d]
+      type t = struct_t builder_t
       val has_name : t -> bool
       val name_get : t -> string
       val name_set : t -> string -> unit
       val code_order_get : t -> int
       val code_order_set_exn : t -> int -> unit
       val has_annotations : t -> bool
-      val annotations_get : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> builder_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> builder_t_Annotation_17422339044421236034 array
-      val annotations_set : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_list : t -> builder_t_Annotation_17422339044421236034 list -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_array : t -> builder_t_Annotation_17422339044421236034 array -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_init : t -> int -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
+      val annotations_get : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] builder_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] builder_t array
+      val annotations_set : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_list : t -> [`Annotation_f1c8950dab257542] builder_t list -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_array : t -> [`Annotation_f1c8950dab257542] builder_t array -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_init : t -> int -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Superclass : sig
-      type t = builder_t_Superclass_12220001500510083064
-      type reader_t = reader_t_Superclass_12220001500510083064
+      type struct_t = [`Superclass_a9962a9ed0a4d7f8]
+      type t = struct_t builder_t
       val id_get : t -> Uint64.t
       val id_get_int_exn : t -> int
       val id_set : t -> Uint64.t -> unit
       val id_set_int_exn : t -> int -> unit
       val has_brand : t -> bool
-      val brand_get : t -> builder_t_Brand_10391024731148337707
-      val brand_set_reader : t -> reader_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-      val brand_set_builder : t -> builder_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-      val brand_init : t -> builder_t_Brand_10391024731148337707
+      val brand_get : t -> [`Brand_903455f06065422b] builder_t
+      val brand_set_reader : t -> [`Brand_903455f06065422b] reader_t -> [`Brand_903455f06065422b] builder_t
+      val brand_set_builder : t -> [`Brand_903455f06065422b] builder_t -> [`Brand_903455f06065422b] builder_t
+      val brand_init : t -> [`Brand_903455f06065422b] builder_t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Method : sig
-      type t = builder_t_Method_10736806783679155584
-      type reader_t = reader_t_Method_10736806783679155584
+      type struct_t = [`Method_9500cce23b334d80]
+      type t = struct_t builder_t
       val has_name : t -> bool
       val name_get : t -> string
       val name_set : t -> string -> unit
@@ -972,110 +873,110 @@ module type S = sig
       val param_struct_type_set : t -> Uint64.t -> unit
       val param_struct_type_set_int_exn : t -> int -> unit
       val has_param_brand : t -> bool
-      val param_brand_get : t -> builder_t_Brand_10391024731148337707
-      val param_brand_set_reader : t -> reader_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-      val param_brand_set_builder : t -> builder_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-      val param_brand_init : t -> builder_t_Brand_10391024731148337707
+      val param_brand_get : t -> [`Brand_903455f06065422b] builder_t
+      val param_brand_set_reader : t -> [`Brand_903455f06065422b] reader_t -> [`Brand_903455f06065422b] builder_t
+      val param_brand_set_builder : t -> [`Brand_903455f06065422b] builder_t -> [`Brand_903455f06065422b] builder_t
+      val param_brand_init : t -> [`Brand_903455f06065422b] builder_t
       val result_struct_type_get : t -> Uint64.t
       val result_struct_type_get_int_exn : t -> int
       val result_struct_type_set : t -> Uint64.t -> unit
       val result_struct_type_set_int_exn : t -> int -> unit
       val has_result_brand : t -> bool
-      val result_brand_get : t -> builder_t_Brand_10391024731148337707
-      val result_brand_set_reader : t -> reader_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-      val result_brand_set_builder : t -> builder_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-      val result_brand_init : t -> builder_t_Brand_10391024731148337707
+      val result_brand_get : t -> [`Brand_903455f06065422b] builder_t
+      val result_brand_set_reader : t -> [`Brand_903455f06065422b] reader_t -> [`Brand_903455f06065422b] builder_t
+      val result_brand_set_builder : t -> [`Brand_903455f06065422b] builder_t -> [`Brand_903455f06065422b] builder_t
+      val result_brand_init : t -> [`Brand_903455f06065422b] builder_t
       val has_annotations : t -> bool
-      val annotations_get : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> builder_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> builder_t_Annotation_17422339044421236034 array
-      val annotations_set : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_list : t -> builder_t_Annotation_17422339044421236034 list -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_array : t -> builder_t_Annotation_17422339044421236034 array -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_init : t -> int -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
+      val annotations_get : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] builder_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] builder_t array
+      val annotations_set : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_list : t -> [`Annotation_f1c8950dab257542] builder_t list -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_array : t -> [`Annotation_f1c8950dab257542] builder_t array -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_init : t -> int -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Type : sig
-      type t = builder_t_Type_15020482145304562784
-      type reader_t = reader_t_Type_15020482145304562784
+      type struct_t = [`Type_d07378ede1f9cc60]
+      type t = struct_t builder_t
       module List : sig
-        type t = builder_t_List_9792858745991129751
-        type reader_t = reader_t_List_9792858745991129751
+        type struct_t = [`List_87e739250a60ea97]
+        type t = struct_t builder_t
         val has_element_type : t -> bool
-        val element_type_get : t -> builder_t_Type_15020482145304562784
-        val element_type_set_reader : t -> reader_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val element_type_set_builder : t -> builder_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val element_type_init : t -> builder_t_Type_15020482145304562784
+        val element_type_get : t -> [`Type_d07378ede1f9cc60] builder_t
+        val element_type_set_reader : t -> [`Type_d07378ede1f9cc60] reader_t -> [`Type_d07378ede1f9cc60] builder_t
+        val element_type_set_builder : t -> [`Type_d07378ede1f9cc60] builder_t -> [`Type_d07378ede1f9cc60] builder_t
+        val element_type_init : t -> [`Type_d07378ede1f9cc60] builder_t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Enum : sig
-        type t = builder_t_Enum_11389172934837766057
-        type reader_t = reader_t_Enum_11389172934837766057
+        type struct_t = [`Enum_9e0e78711a7f87a9]
+        type t = struct_t builder_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val type_id_set : t -> Uint64.t -> unit
         val type_id_set_int_exn : t -> int -> unit
         val has_brand : t -> bool
-        val brand_get : t -> builder_t_Brand_10391024731148337707
-        val brand_set_reader : t -> reader_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-        val brand_set_builder : t -> builder_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-        val brand_init : t -> builder_t_Brand_10391024731148337707
+        val brand_get : t -> [`Brand_903455f06065422b] builder_t
+        val brand_set_reader : t -> [`Brand_903455f06065422b] reader_t -> [`Brand_903455f06065422b] builder_t
+        val brand_set_builder : t -> [`Brand_903455f06065422b] builder_t -> [`Brand_903455f06065422b] builder_t
+        val brand_init : t -> [`Brand_903455f06065422b] builder_t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Struct : sig
-        type t = builder_t_Struct_12410354185295152851
-        type reader_t = reader_t_Struct_12410354185295152851
+        type struct_t = [`Struct_ac3a6f60ef4cc6d3]
+        type t = struct_t builder_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val type_id_set : t -> Uint64.t -> unit
         val type_id_set_int_exn : t -> int -> unit
         val has_brand : t -> bool
-        val brand_get : t -> builder_t_Brand_10391024731148337707
-        val brand_set_reader : t -> reader_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-        val brand_set_builder : t -> builder_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-        val brand_init : t -> builder_t_Brand_10391024731148337707
+        val brand_get : t -> [`Brand_903455f06065422b] builder_t
+        val brand_set_reader : t -> [`Brand_903455f06065422b] reader_t -> [`Brand_903455f06065422b] builder_t
+        val brand_set_builder : t -> [`Brand_903455f06065422b] builder_t -> [`Brand_903455f06065422b] builder_t
+        val brand_init : t -> [`Brand_903455f06065422b] builder_t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Interface : sig
-        type t = builder_t_Interface_17116997365232503999
-        type reader_t = reader_t_Interface_17116997365232503999
+        type struct_t = [`Interface_ed8bca69f7fb0cbf]
+        type t = struct_t builder_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val type_id_set : t -> Uint64.t -> unit
         val type_id_set_int_exn : t -> int -> unit
         val has_brand : t -> bool
-        val brand_get : t -> builder_t_Brand_10391024731148337707
-        val brand_set_reader : t -> reader_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-        val brand_set_builder : t -> builder_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-        val brand_init : t -> builder_t_Brand_10391024731148337707
+        val brand_get : t -> [`Brand_903455f06065422b] builder_t
+        val brand_set_reader : t -> [`Brand_903455f06065422b] reader_t -> [`Brand_903455f06065422b] builder_t
+        val brand_set_builder : t -> [`Brand_903455f06065422b] builder_t -> [`Brand_903455f06065422b] builder_t
+        val brand_init : t -> [`Brand_903455f06065422b] builder_t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module AnyPointer : sig
-        type t = builder_t_AnyPointer_14003731834718800369
-        type reader_t = reader_t_AnyPointer_14003731834718800369
+        type struct_t = [`AnyPointer_c2573fe8a23e49f1]
+        type t = struct_t builder_t
         module Unconstrained : sig
-          type t = builder_t_Unconstrained_10248890354574636630
-          type reader_t = reader_t_Unconstrained_10248890354574636630
+          type struct_t = [`Unconstrained_8e3b5f79fe593656]
+          type t = struct_t builder_t
           type unnamed_union_t =
             | AnyKind
             | Struct
@@ -1089,13 +990,13 @@ module type S = sig
           val capability_set : t -> unit
           val of_message : rw message_t -> t
           val to_message : t -> rw message_t
-          val to_reader : t -> reader_t
+          val to_reader : t -> struct_t reader_t
           val init_root : ?message_size:int -> unit -> t
           val init_pointer : pointer_t -> t
         end
         module Parameter : sig
-          type t = builder_t_Parameter_11372142272178113157
-          type reader_t = reader_t_Parameter_11372142272178113157
+          type struct_t = [`Parameter_9dd1f724f4614a85]
+          type t = struct_t builder_t
           val scope_id_get : t -> Uint64.t
           val scope_id_get_int_exn : t -> int
           val scope_id_set : t -> Uint64.t -> unit
@@ -1104,18 +1005,18 @@ module type S = sig
           val parameter_index_set_exn : t -> int -> unit
           val of_message : rw message_t -> t
           val to_message : t -> rw message_t
-          val to_reader : t -> reader_t
+          val to_reader : t -> struct_t reader_t
           val init_root : ?message_size:int -> unit -> t
           val init_pointer : pointer_t -> t
         end
         module ImplicitMethodParameter : sig
-          type t = builder_t_ImplicitMethodParameter_13470206089842057844
-          type reader_t = reader_t_ImplicitMethodParameter_13470206089842057844
+          type struct_t = [`ImplicitMethodParameter_baefc9120c56e274]
+          type t = struct_t builder_t
           val parameter_index_get : t -> int
           val parameter_index_set_exn : t -> int -> unit
           val of_message : rw message_t -> t
           val to_message : t -> rw message_t
-          val to_reader : t -> reader_t
+          val to_reader : t -> struct_t reader_t
           val init_root : ?message_size:int -> unit -> t
           val init_pointer : pointer_t -> t
         end
@@ -1130,7 +1031,7 @@ module type S = sig
         val implicit_method_parameter_init : t -> ImplicitMethodParameter.t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
@@ -1177,25 +1078,25 @@ module type S = sig
       val any_pointer_init : t -> AnyPointer.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Brand : sig
-      type t = builder_t_Brand_10391024731148337707
-      type reader_t = reader_t_Brand_10391024731148337707
+      type struct_t = [`Brand_903455f06065422b]
+      type t = struct_t builder_t
       module Scope : sig
-        type t = builder_t_Scope_12382423449155627977
-        type reader_t = reader_t_Scope_12382423449155627977
+        type struct_t = [`Scope_abd73485a9636bc9]
+        type t = struct_t builder_t
         type unnamed_union_t =
-          | Bind of (rw, builder_t_Binding_14439610327179913212, array_t) Capnp.Array.t
+          | Bind of (rw, [`Binding_c863cd16969ee7fc] builder_t, array_t) Capnp.Array.t
           | Inherit
           | Undefined of int
         val get : t -> unnamed_union_t
-        val bind_set : t -> (rw, builder_t_Binding_14439610327179913212, array_t) Capnp.Array.t -> (rw, builder_t_Binding_14439610327179913212, array_t) Capnp.Array.t
-        val bind_set_list : t -> builder_t_Binding_14439610327179913212 list -> (rw, builder_t_Binding_14439610327179913212, array_t) Capnp.Array.t
-        val bind_set_array : t -> builder_t_Binding_14439610327179913212 array -> (rw, builder_t_Binding_14439610327179913212, array_t) Capnp.Array.t
-        val bind_init : t -> int -> (rw, builder_t_Binding_14439610327179913212, array_t) Capnp.Array.t
+        val bind_set : t -> (rw, [`Binding_c863cd16969ee7fc] builder_t, array_t) Capnp.Array.t -> (rw, [`Binding_c863cd16969ee7fc] builder_t, array_t) Capnp.Array.t
+        val bind_set_list : t -> [`Binding_c863cd16969ee7fc] builder_t list -> (rw, [`Binding_c863cd16969ee7fc] builder_t, array_t) Capnp.Array.t
+        val bind_set_array : t -> [`Binding_c863cd16969ee7fc] builder_t array -> (rw, [`Binding_c863cd16969ee7fc] builder_t, array_t) Capnp.Array.t
+        val bind_init : t -> int -> (rw, [`Binding_c863cd16969ee7fc] builder_t, array_t) Capnp.Array.t
         val inherit_set : t -> unit
         val scope_id_get : t -> Uint64.t
         val scope_id_get_int_exn : t -> int
@@ -1203,45 +1104,45 @@ module type S = sig
         val scope_id_set_int_exn : t -> int -> unit
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Binding : sig
-        type t = builder_t_Binding_14439610327179913212
-        type reader_t = reader_t_Binding_14439610327179913212
+        type struct_t = [`Binding_c863cd16969ee7fc]
+        type t = struct_t builder_t
         type unnamed_union_t =
           | Unbound
           | Type of Type.t
           | Undefined of int
         val get : t -> unnamed_union_t
         val unbound_set : t -> unit
-        val type_set_reader : t -> Type.reader_t -> Type.t
+        val type_set_reader : t -> Type.struct_t reader_t -> Type.t
         val type_set_builder : t -> Type.t -> Type.t
         val type_init : t -> Type.t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       val has_scopes : t -> bool
-      val scopes_get : t -> (rw, builder_t_Scope_12382423449155627977, array_t) Capnp.Array.t
-      val scopes_get_list : t -> builder_t_Scope_12382423449155627977 list
-      val scopes_get_array : t -> builder_t_Scope_12382423449155627977 array
-      val scopes_set : t -> (rw, builder_t_Scope_12382423449155627977, array_t) Capnp.Array.t -> (rw, builder_t_Scope_12382423449155627977, array_t) Capnp.Array.t
-      val scopes_set_list : t -> builder_t_Scope_12382423449155627977 list -> (rw, builder_t_Scope_12382423449155627977, array_t) Capnp.Array.t
-      val scopes_set_array : t -> builder_t_Scope_12382423449155627977 array -> (rw, builder_t_Scope_12382423449155627977, array_t) Capnp.Array.t
-      val scopes_init : t -> int -> (rw, builder_t_Scope_12382423449155627977, array_t) Capnp.Array.t
+      val scopes_get : t -> (rw, [`Scope_abd73485a9636bc9] builder_t, array_t) Capnp.Array.t
+      val scopes_get_list : t -> [`Scope_abd73485a9636bc9] builder_t list
+      val scopes_get_array : t -> [`Scope_abd73485a9636bc9] builder_t array
+      val scopes_set : t -> (rw, [`Scope_abd73485a9636bc9] builder_t, array_t) Capnp.Array.t -> (rw, [`Scope_abd73485a9636bc9] builder_t, array_t) Capnp.Array.t
+      val scopes_set_list : t -> [`Scope_abd73485a9636bc9] builder_t list -> (rw, [`Scope_abd73485a9636bc9] builder_t, array_t) Capnp.Array.t
+      val scopes_set_array : t -> [`Scope_abd73485a9636bc9] builder_t array -> (rw, [`Scope_abd73485a9636bc9] builder_t, array_t) Capnp.Array.t
+      val scopes_init : t -> int -> (rw, [`Scope_abd73485a9636bc9] builder_t, array_t) Capnp.Array.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Value : sig
-      type t = builder_t_Value_14853958794117909659
-      type reader_t = reader_t_Value_14853958794117909659
+      type struct_t = [`Value_ce23dcd2d7b00c9b]
+      type t = struct_t builder_t
       type unnamed_union_t =
         | Void
         | Bool of bool
@@ -1295,30 +1196,30 @@ module type S = sig
       val any_pointer_set_interface : t -> Uint32.t option -> unit
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Annotation : sig
-      type t = builder_t_Annotation_17422339044421236034
-      type reader_t = reader_t_Annotation_17422339044421236034
+      type struct_t = [`Annotation_f1c8950dab257542]
+      type t = struct_t builder_t
       val id_get : t -> Uint64.t
       val id_get_int_exn : t -> int
       val id_set : t -> Uint64.t -> unit
       val id_set_int_exn : t -> int -> unit
       val has_brand : t -> bool
       val brand_get : t -> Brand.t
-      val brand_set_reader : t -> Brand.reader_t -> Brand.t
+      val brand_set_reader : t -> Brand.struct_t reader_t -> Brand.t
       val brand_set_builder : t -> Brand.t -> Brand.t
       val brand_init : t -> Brand.t
       val has_value : t -> bool
       val value_get : t -> Value.t
-      val value_set_reader : t -> Value.reader_t -> Value.t
+      val value_set_reader : t -> Value.struct_t reader_t -> Value.t
       val value_set_builder : t -> Value.t -> Value.t
       val value_init : t -> Value.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
@@ -1335,8 +1236,8 @@ module type S = sig
         | Undefined of int
     end
     module CapnpVersion : sig
-      type t = builder_t_CapnpVersion_15590670654532458851
-      type reader_t = reader_t_CapnpVersion_15590670654532458851
+      type struct_t = [`CapnpVersion_d85d305b7d839963]
+      type t = struct_t builder_t
       val major_get : t -> int
       val major_set_exn : t -> int -> unit
       val minor_get : t -> int
@@ -1345,19 +1246,19 @@ module type S = sig
       val micro_set_exn : t -> int -> unit
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module CodeGeneratorRequest : sig
-      type t = builder_t_CodeGeneratorRequest_13818529054586492878
-      type reader_t = reader_t_CodeGeneratorRequest_13818529054586492878
+      type struct_t = [`CodeGeneratorRequest_bfc546f6210ad7ce]
+      type t = struct_t builder_t
       module RequestedFile : sig
-        type t = builder_t_RequestedFile_14981803260258615394
-        type reader_t = reader_t_RequestedFile_14981803260258615394
+        type struct_t = [`RequestedFile_cfea0eb02e810062]
+        type t = struct_t builder_t
         module Import : sig
-          type t = builder_t_Import_12560611460656617445
-          type reader_t = reader_t_Import_12560611460656617445
+          type struct_t = [`Import_ae504193122357e5]
+          type t = struct_t builder_t
           val id_get : t -> Uint64.t
           val id_get_int_exn : t -> int
           val id_set : t -> Uint64.t -> unit
@@ -1367,7 +1268,7 @@ module type S = sig
           val name_set : t -> string -> unit
           val of_message : rw message_t -> t
           val to_message : t -> rw message_t
-          val to_reader : t -> reader_t
+          val to_reader : t -> struct_t reader_t
           val init_root : ?message_size:int -> unit -> t
           val init_pointer : pointer_t -> t
         end
@@ -1379,22 +1280,22 @@ module type S = sig
         val filename_get : t -> string
         val filename_set : t -> string -> unit
         val has_imports : t -> bool
-        val imports_get : t -> (rw, builder_t_Import_12560611460656617445, array_t) Capnp.Array.t
-        val imports_get_list : t -> builder_t_Import_12560611460656617445 list
-        val imports_get_array : t -> builder_t_Import_12560611460656617445 array
-        val imports_set : t -> (rw, builder_t_Import_12560611460656617445, array_t) Capnp.Array.t -> (rw, builder_t_Import_12560611460656617445, array_t) Capnp.Array.t
-        val imports_set_list : t -> builder_t_Import_12560611460656617445 list -> (rw, builder_t_Import_12560611460656617445, array_t) Capnp.Array.t
-        val imports_set_array : t -> builder_t_Import_12560611460656617445 array -> (rw, builder_t_Import_12560611460656617445, array_t) Capnp.Array.t
-        val imports_init : t -> int -> (rw, builder_t_Import_12560611460656617445, array_t) Capnp.Array.t
+        val imports_get : t -> (rw, [`Import_ae504193122357e5] builder_t, array_t) Capnp.Array.t
+        val imports_get_list : t -> [`Import_ae504193122357e5] builder_t list
+        val imports_get_array : t -> [`Import_ae504193122357e5] builder_t array
+        val imports_set : t -> (rw, [`Import_ae504193122357e5] builder_t, array_t) Capnp.Array.t -> (rw, [`Import_ae504193122357e5] builder_t, array_t) Capnp.Array.t
+        val imports_set_list : t -> [`Import_ae504193122357e5] builder_t list -> (rw, [`Import_ae504193122357e5] builder_t, array_t) Capnp.Array.t
+        val imports_set_array : t -> [`Import_ae504193122357e5] builder_t array -> (rw, [`Import_ae504193122357e5] builder_t, array_t) Capnp.Array.t
+        val imports_init : t -> int -> (rw, [`Import_ae504193122357e5] builder_t, array_t) Capnp.Array.t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       val has_capnp_version : t -> bool
       val capnp_version_get : t -> CapnpVersion.t
-      val capnp_version_set_reader : t -> CapnpVersion.reader_t -> CapnpVersion.t
+      val capnp_version_set_reader : t -> CapnpVersion.struct_t reader_t -> CapnpVersion.t
       val capnp_version_set_builder : t -> CapnpVersion.t -> CapnpVersion.t
       val capnp_version_init : t -> CapnpVersion.t
       val has_nodes : t -> bool
@@ -1406,16 +1307,16 @@ module type S = sig
       val nodes_set_array : t -> Node.t array -> (rw, Node.t, array_t) Capnp.Array.t
       val nodes_init : t -> int -> (rw, Node.t, array_t) Capnp.Array.t
       val has_requested_files : t -> bool
-      val requested_files_get : t -> (rw, builder_t_RequestedFile_14981803260258615394, array_t) Capnp.Array.t
-      val requested_files_get_list : t -> builder_t_RequestedFile_14981803260258615394 list
-      val requested_files_get_array : t -> builder_t_RequestedFile_14981803260258615394 array
-      val requested_files_set : t -> (rw, builder_t_RequestedFile_14981803260258615394, array_t) Capnp.Array.t -> (rw, builder_t_RequestedFile_14981803260258615394, array_t) Capnp.Array.t
-      val requested_files_set_list : t -> builder_t_RequestedFile_14981803260258615394 list -> (rw, builder_t_RequestedFile_14981803260258615394, array_t) Capnp.Array.t
-      val requested_files_set_array : t -> builder_t_RequestedFile_14981803260258615394 array -> (rw, builder_t_RequestedFile_14981803260258615394, array_t) Capnp.Array.t
-      val requested_files_init : t -> int -> (rw, builder_t_RequestedFile_14981803260258615394, array_t) Capnp.Array.t
+      val requested_files_get : t -> (rw, [`RequestedFile_cfea0eb02e810062] builder_t, array_t) Capnp.Array.t
+      val requested_files_get_list : t -> [`RequestedFile_cfea0eb02e810062] builder_t list
+      val requested_files_get_array : t -> [`RequestedFile_cfea0eb02e810062] builder_t array
+      val requested_files_set : t -> (rw, [`RequestedFile_cfea0eb02e810062] builder_t, array_t) Capnp.Array.t -> (rw, [`RequestedFile_cfea0eb02e810062] builder_t, array_t) Capnp.Array.t
+      val requested_files_set_list : t -> [`RequestedFile_cfea0eb02e810062] builder_t list -> (rw, [`RequestedFile_cfea0eb02e810062] builder_t, array_t) Capnp.Array.t
+      val requested_files_set_array : t -> [`RequestedFile_cfea0eb02e810062] builder_t array -> (rw, [`RequestedFile_cfea0eb02e810062] builder_t, array_t) Capnp.Array.t
+      val requested_files_init : t -> int -> (rw, [`RequestedFile_cfea0eb02e810062] builder_t, array_t) Capnp.Array.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
@@ -1441,106 +1342,6 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
   include Capnp.Runtime.BuilderInc.Make[@inlined](MessageWrapper)
 
   type 'cap message_t = 'cap MessageWrapper.Message.t
-
-  type struct_Import_12560611460656617445
-  type reader_t_Import_12560611460656617445 = struct_Import_12560611460656617445 reader_t
-  type builder_t_Import_12560611460656617445 = struct_Import_12560611460656617445 builder_t
-  type struct_RequestedFile_14981803260258615394
-  type reader_t_RequestedFile_14981803260258615394 = struct_RequestedFile_14981803260258615394 reader_t
-  type builder_t_RequestedFile_14981803260258615394 = struct_RequestedFile_14981803260258615394 builder_t
-  type struct_CodeGeneratorRequest_13818529054586492878
-  type reader_t_CodeGeneratorRequest_13818529054586492878 = struct_CodeGeneratorRequest_13818529054586492878 reader_t
-  type builder_t_CodeGeneratorRequest_13818529054586492878 = struct_CodeGeneratorRequest_13818529054586492878 builder_t
-  type struct_CapnpVersion_15590670654532458851
-  type reader_t_CapnpVersion_15590670654532458851 = struct_CapnpVersion_15590670654532458851 reader_t
-  type builder_t_CapnpVersion_15590670654532458851 = struct_CapnpVersion_15590670654532458851 builder_t
-  type struct_Annotation_17422339044421236034
-  type reader_t_Annotation_17422339044421236034 = struct_Annotation_17422339044421236034 reader_t
-  type builder_t_Annotation_17422339044421236034 = struct_Annotation_17422339044421236034 builder_t
-  type struct_Value_14853958794117909659
-  type reader_t_Value_14853958794117909659 = struct_Value_14853958794117909659 reader_t
-  type builder_t_Value_14853958794117909659 = struct_Value_14853958794117909659 builder_t
-  type struct_Binding_14439610327179913212
-  type reader_t_Binding_14439610327179913212 = struct_Binding_14439610327179913212 reader_t
-  type builder_t_Binding_14439610327179913212 = struct_Binding_14439610327179913212 builder_t
-  type struct_Scope_12382423449155627977
-  type reader_t_Scope_12382423449155627977 = struct_Scope_12382423449155627977 reader_t
-  type builder_t_Scope_12382423449155627977 = struct_Scope_12382423449155627977 builder_t
-  type struct_Brand_10391024731148337707
-  type reader_t_Brand_10391024731148337707 = struct_Brand_10391024731148337707 reader_t
-  type builder_t_Brand_10391024731148337707 = struct_Brand_10391024731148337707 builder_t
-  type struct_ImplicitMethodParameter_13470206089842057844
-  type reader_t_ImplicitMethodParameter_13470206089842057844 = struct_ImplicitMethodParameter_13470206089842057844 reader_t
-  type builder_t_ImplicitMethodParameter_13470206089842057844 = struct_ImplicitMethodParameter_13470206089842057844 builder_t
-  type struct_Parameter_11372142272178113157
-  type reader_t_Parameter_11372142272178113157 = struct_Parameter_11372142272178113157 reader_t
-  type builder_t_Parameter_11372142272178113157 = struct_Parameter_11372142272178113157 builder_t
-  type struct_Unconstrained_10248890354574636630
-  type reader_t_Unconstrained_10248890354574636630 = struct_Unconstrained_10248890354574636630 reader_t
-  type builder_t_Unconstrained_10248890354574636630 = struct_Unconstrained_10248890354574636630 builder_t
-  type struct_AnyPointer_14003731834718800369
-  type reader_t_AnyPointer_14003731834718800369 = struct_AnyPointer_14003731834718800369 reader_t
-  type builder_t_AnyPointer_14003731834718800369 = struct_AnyPointer_14003731834718800369 builder_t
-  type struct_Interface_17116997365232503999
-  type reader_t_Interface_17116997365232503999 = struct_Interface_17116997365232503999 reader_t
-  type builder_t_Interface_17116997365232503999 = struct_Interface_17116997365232503999 builder_t
-  type struct_Struct_12410354185295152851
-  type reader_t_Struct_12410354185295152851 = struct_Struct_12410354185295152851 reader_t
-  type builder_t_Struct_12410354185295152851 = struct_Struct_12410354185295152851 builder_t
-  type struct_Enum_11389172934837766057
-  type reader_t_Enum_11389172934837766057 = struct_Enum_11389172934837766057 reader_t
-  type builder_t_Enum_11389172934837766057 = struct_Enum_11389172934837766057 builder_t
-  type struct_List_9792858745991129751
-  type reader_t_List_9792858745991129751 = struct_List_9792858745991129751 reader_t
-  type builder_t_List_9792858745991129751 = struct_List_9792858745991129751 builder_t
-  type struct_Type_15020482145304562784
-  type reader_t_Type_15020482145304562784 = struct_Type_15020482145304562784 reader_t
-  type builder_t_Type_15020482145304562784 = struct_Type_15020482145304562784 builder_t
-  type struct_Method_10736806783679155584
-  type reader_t_Method_10736806783679155584 = struct_Method_10736806783679155584 reader_t
-  type builder_t_Method_10736806783679155584 = struct_Method_10736806783679155584 builder_t
-  type struct_Superclass_12220001500510083064
-  type reader_t_Superclass_12220001500510083064 = struct_Superclass_12220001500510083064 reader_t
-  type builder_t_Superclass_12220001500510083064 = struct_Superclass_12220001500510083064 builder_t
-  type struct_Enumerant_10919677598968879693
-  type reader_t_Enumerant_10919677598968879693 = struct_Enumerant_10919677598968879693 reader_t
-  type builder_t_Enumerant_10919677598968879693 = struct_Enumerant_10919677598968879693 builder_t
-  type struct_Ordinal_13515537513213004774
-  type reader_t_Ordinal_13515537513213004774 = struct_Ordinal_13515537513213004774 reader_t
-  type builder_t_Ordinal_13515537513213004774 = struct_Ordinal_13515537513213004774 builder_t
-  type struct_Group_14626792032033250577
-  type reader_t_Group_14626792032033250577 = struct_Group_14626792032033250577 reader_t
-  type builder_t_Group_14626792032033250577 = struct_Group_14626792032033250577 builder_t
-  type struct_Slot_14133145859926553711
-  type reader_t_Slot_14133145859926553711 = struct_Slot_14133145859926553711 reader_t
-  type builder_t_Slot_14133145859926553711 = struct_Slot_14133145859926553711 builder_t
-  type struct_Field_11145653318641710175
-  type reader_t_Field_11145653318641710175 = struct_Field_11145653318641710175 reader_t
-  type builder_t_Field_11145653318641710175 = struct_Field_11145653318641710175 builder_t
-  type struct_NestedNode_16050641862814319170
-  type reader_t_NestedNode_16050641862814319170 = struct_NestedNode_16050641862814319170 reader_t
-  type builder_t_NestedNode_16050641862814319170 = struct_NestedNode_16050641862814319170 builder_t
-  type struct_Parameter_13353766412138554289
-  type reader_t_Parameter_13353766412138554289 = struct_Parameter_13353766412138554289 reader_t
-  type builder_t_Parameter_13353766412138554289 = struct_Parameter_13353766412138554289 builder_t
-  type struct_Annotation_17011813041836786320
-  type reader_t_Annotation_17011813041836786320 = struct_Annotation_17011813041836786320 reader_t
-  type builder_t_Annotation_17011813041836786320 = struct_Annotation_17011813041836786320 builder_t
-  type struct_Const_12793219851699983392
-  type reader_t_Const_12793219851699983392 = struct_Const_12793219851699983392 reader_t
-  type builder_t_Const_12793219851699983392 = struct_Const_12793219851699983392 builder_t
-  type struct_Interface_16728431493453586831
-  type reader_t_Interface_16728431493453586831 = struct_Interface_16728431493453586831 reader_t
-  type builder_t_Interface_16728431493453586831 = struct_Interface_16728431493453586831 builder_t
-  type struct_Enum_13063450714778629528
-  type reader_t_Enum_13063450714778629528 = struct_Enum_13063450714778629528 reader_t
-  type builder_t_Enum_13063450714778629528 = struct_Enum_13063450714778629528 builder_t
-  type struct_Struct_11430331134483579957
-  type reader_t_Struct_11430331134483579957 = struct_Struct_11430331134483579957 reader_t
-  type builder_t_Struct_11430331134483579957 = struct_Struct_11430331134483579957 builder_t
-  type struct_Node_16610026722781537303
-  type reader_t_Node_16610026722781537303 = struct_Node_16610026722781537303 reader_t
-  type builder_t_Node_16610026722781537303 = struct_Node_16610026722781537303 builder_t
 
   module ElementSize_15102134695616452902 = struct
     type t =
@@ -1599,11 +1400,11 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
     let of_pointer = RA_.deref_opt_struct_pointer
 
     module Node = struct
-      type t = reader_t_Node_16610026722781537303
-      type builder_t = builder_t_Node_16610026722781537303
+      type struct_t = [`Node_e682ab4cf923a417]
+      type t = struct_t reader_t
       module Struct = struct
-        type t = reader_t_Struct_11430331134483579957
-        type builder_t = builder_t_Struct_11430331134483579957
+        type struct_t = [`Struct_9ea0b19b37fb4435]
+        type t = struct_t reader_t
         let data_word_count_get x =
           RA_.get_uint16 ~default:0 x 14
         let pointer_count_get x =
@@ -1619,10 +1420,10 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           RA_.get_uint32 ~default:Uint32.zero x 32
         let discriminant_offset_get_int_exn x =
           Capnp.Runtime.Util.int_of_uint32_exn (discriminant_offset_get x)
-        let has_fields x = 
-          (RA_.has_field x 3)
+        let has_fields x =
+          RA_.has_field x 3
         let fields_get x = 
-          (RA_.get_struct_list x 3)
+          RA_.get_struct_list x 3
         let fields_get_list x =
           Capnp.Array.to_list (fields_get x)
         let fields_get_array x =
@@ -1631,12 +1432,12 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
       module Enum = struct
-        type t = reader_t_Enum_13063450714778629528
-        type builder_t = builder_t_Enum_13063450714778629528
-        let has_enumerants x = 
-          (RA_.has_field x 3)
+        type struct_t = [`Enum_b54ab3364333f598]
+        type t = struct_t reader_t
+        let has_enumerants x =
+          RA_.has_field x 3
         let enumerants_get x = 
-          (RA_.get_struct_list x 3)
+          RA_.get_struct_list x 3
         let enumerants_get_list x =
           Capnp.Array.to_list (enumerants_get x)
         let enumerants_get_array x =
@@ -1645,20 +1446,20 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
       module Interface = struct
-        type t = reader_t_Interface_16728431493453586831
-        type builder_t = builder_t_Interface_16728431493453586831
-        let has_methods x = 
-          (RA_.has_field x 3)
+        type struct_t = [`Interface_e82753cff0c2218f]
+        type t = struct_t reader_t
+        let has_methods x =
+          RA_.has_field x 3
         let methods_get x = 
-          (RA_.get_struct_list x 3)
+          RA_.get_struct_list x 3
         let methods_get_list x =
           Capnp.Array.to_list (methods_get x)
         let methods_get_array x =
           Capnp.Array.to_array (methods_get x)
-        let has_superclasses x = 
-          (RA_.has_field x 4)
+        let has_superclasses x =
+          RA_.has_field x 4
         let superclasses_get x = 
-          (RA_.get_struct_list x 4)
+          RA_.get_struct_list x 4
         let superclasses_get_list x =
           Capnp.Array.to_list (superclasses_get x)
         let superclasses_get_array x =
@@ -1667,26 +1468,26 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
       module Const = struct
-        type t = reader_t_Const_12793219851699983392
-        type builder_t = builder_t_Const_12793219851699983392
-        let has_type x = 
-          (RA_.has_field x 3)
-        let type_get x = 
-          (RA_.get_struct x 3)
-        let has_value x = 
-          (RA_.has_field x 4)
-        let value_get x = 
-          (RA_.get_struct x 4)
+        type struct_t = [`Const_b18aa5ac7a0d9420]
+        type t = struct_t reader_t
+        let has_type x =
+          RA_.has_field x 3
+        let type_get x =
+          RA_.get_struct x 3
+        let has_value x =
+          RA_.has_field x 4
+        let value_get x =
+          RA_.get_struct x 4
         let of_message x = RA_.get_root_struct (RA_.Message.readonly x)
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
       module Annotation = struct
-        type t = reader_t_Annotation_17011813041836786320
-        type builder_t = builder_t_Annotation_17011813041836786320
-        let has_type x = 
-          (RA_.has_field x 3)
-        let type_get x = 
-          (RA_.get_struct x 3)
+        type struct_t = [`Annotation_ec1619d4400a0290]
+        type t = struct_t reader_t
+        let has_type x =
+          RA_.has_field x 3
+        let type_get x =
+          RA_.get_struct x 3
         let targets_file_get x =
           RA_.get_bit ~default:false x ~byte_ofs:14 ~bit_ofs:0
         let targets_const_get x =
@@ -1715,8 +1516,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
       module Parameter = struct
-        type t = reader_t_Parameter_13353766412138554289
-        type builder_t = builder_t_Parameter_13353766412138554289
+        type struct_t = [`Parameter_b9521bccf10fa3b1]
+        type t = struct_t reader_t
         let has_name x =
           RA_.has_field x 0
         let name_get x =
@@ -1725,8 +1526,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
       module NestedNode = struct
-        type t = reader_t_NestedNode_16050641862814319170
-        type builder_t = builder_t_NestedNode_16050641862814319170
+        type struct_t = [`NestedNode_debf55bbfa0fc242]
+        type t = struct_t reader_t
         let has_name x =
           RA_.has_field x 0
         let name_get x =
@@ -1777,28 +1578,28 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         RA_.get_uint64 ~default:Uint64.zero x 16
       let scope_id_get_int_exn x =
         Capnp.Runtime.Util.int_of_uint64_exn (scope_id_get x)
-      let has_parameters x = 
-        (RA_.has_field x 5)
+      let has_parameters x =
+        RA_.has_field x 5
       let parameters_get x = 
-        (RA_.get_struct_list x 5)
+        RA_.get_struct_list x 5
       let parameters_get_list x =
         Capnp.Array.to_list (parameters_get x)
       let parameters_get_array x =
         Capnp.Array.to_array (parameters_get x)
       let is_generic_get x =
         RA_.get_bit ~default:false x ~byte_ofs:36 ~bit_ofs:0
-      let has_nested_nodes x = 
-        (RA_.has_field x 1)
+      let has_nested_nodes x =
+        RA_.has_field x 1
       let nested_nodes_get x = 
-        (RA_.get_struct_list x 1)
+        RA_.get_struct_list x 1
       let nested_nodes_get_list x =
         Capnp.Array.to_list (nested_nodes_get x)
       let nested_nodes_get_array x =
         Capnp.Array.to_array (nested_nodes_get x)
-      let has_annotations x = 
-        (RA_.has_field x 2)
+      let has_annotations x =
+        RA_.has_field x 2
       let annotations_get x = 
-        (RA_.get_struct_list x 2)
+        RA_.get_struct_list x 2
       let annotations_get_list x =
         Capnp.Array.to_list (annotations_get x)
       let annotations_get_array x =
@@ -1807,31 +1608,31 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let of_builder x = Some (RA_.StructStorage.readonly x)
     end
     module Field = struct
-      type t = reader_t_Field_11145653318641710175
-      type builder_t = builder_t_Field_11145653318641710175
+      type struct_t = [`Field_9aad50a41f4af45f]
+      type t = struct_t reader_t
       module Slot = struct
-        type t = reader_t_Slot_14133145859926553711
-        type builder_t = builder_t_Slot_14133145859926553711
+        type struct_t = [`Slot_c42305476bb4746f]
+        type t = struct_t reader_t
         let offset_get x =
           RA_.get_uint32 ~default:Uint32.zero x 4
         let offset_get_int_exn x =
           Capnp.Runtime.Util.int_of_uint32_exn (offset_get x)
-        let has_type x = 
-          (RA_.has_field x 2)
-        let type_get x = 
-          (RA_.get_struct x 2)
-        let has_default_value x = 
-          (RA_.has_field x 3)
-        let default_value_get x = 
-          (RA_.get_struct x 3)
+        let has_type x =
+          RA_.has_field x 2
+        let type_get x =
+          RA_.get_struct x 2
+        let has_default_value x =
+          RA_.has_field x 3
+        let default_value_get x =
+          RA_.get_struct x 3
         let had_explicit_default_get x =
           RA_.get_bit ~default:false x ~byte_ofs:16 ~bit_ofs:0
         let of_message x = RA_.get_root_struct (RA_.Message.readonly x)
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
       module Group = struct
-        type t = reader_t_Group_14626792032033250577
-        type builder_t = builder_t_Group_14626792032033250577
+        type struct_t = [`Group_cafccddb68db1d11]
+        type t = struct_t reader_t
         let type_id_get x =
           RA_.get_uint64 ~default:Uint64.zero x 16
         let type_id_get_int_exn x =
@@ -1840,8 +1641,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
       module Ordinal = struct
-        type t = reader_t_Ordinal_13515537513213004774
-        type builder_t = builder_t_Ordinal_13515537513213004774
+        type struct_t = [`Ordinal_bb90d5c287870be6]
+        type t = struct_t reader_t
         let implicit_get x = ()
         let explicit_get x =
           RA_.get_uint16 ~default:0 x 12
@@ -1876,10 +1677,10 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         RA_.get_text ~default:"" x 0
       let code_order_get x =
         RA_.get_uint16 ~default:0 x 0
-      let has_annotations x = 
-        (RA_.has_field x 1)
+      let has_annotations x =
+        RA_.has_field x 1
       let annotations_get x = 
-        (RA_.get_struct_list x 1)
+        RA_.get_struct_list x 1
       let annotations_get_list x =
         Capnp.Array.to_list (annotations_get x)
       let annotations_get_array x =
@@ -1891,18 +1692,18 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let of_builder x = Some (RA_.StructStorage.readonly x)
     end
     module Enumerant = struct
-      type t = reader_t_Enumerant_10919677598968879693
-      type builder_t = builder_t_Enumerant_10919677598968879693
+      type struct_t = [`Enumerant_978a7cebdc549a4d]
+      type t = struct_t reader_t
       let has_name x =
         RA_.has_field x 0
       let name_get x =
         RA_.get_text ~default:"" x 0
       let code_order_get x =
         RA_.get_uint16 ~default:0 x 0
-      let has_annotations x = 
-        (RA_.has_field x 1)
+      let has_annotations x =
+        RA_.has_field x 1
       let annotations_get x = 
-        (RA_.get_struct_list x 1)
+        RA_.get_struct_list x 1
       let annotations_get_list x =
         Capnp.Array.to_list (annotations_get x)
       let annotations_get_array x =
@@ -1911,32 +1712,32 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let of_builder x = Some (RA_.StructStorage.readonly x)
     end
     module Superclass = struct
-      type t = reader_t_Superclass_12220001500510083064
-      type builder_t = builder_t_Superclass_12220001500510083064
+      type struct_t = [`Superclass_a9962a9ed0a4d7f8]
+      type t = struct_t reader_t
       let id_get x =
         RA_.get_uint64 ~default:Uint64.zero x 0
       let id_get_int_exn x =
         Capnp.Runtime.Util.int_of_uint64_exn (id_get x)
-      let has_brand x = 
-        (RA_.has_field x 0)
-      let brand_get x = 
-        (RA_.get_struct x 0)
+      let has_brand x =
+        RA_.has_field x 0
+      let brand_get x =
+        RA_.get_struct x 0
       let of_message x = RA_.get_root_struct (RA_.Message.readonly x)
       let of_builder x = Some (RA_.StructStorage.readonly x)
     end
     module Method = struct
-      type t = reader_t_Method_10736806783679155584
-      type builder_t = builder_t_Method_10736806783679155584
+      type struct_t = [`Method_9500cce23b334d80]
+      type t = struct_t reader_t
       let has_name x =
         RA_.has_field x 0
       let name_get x =
         RA_.get_text ~default:"" x 0
       let code_order_get x =
         RA_.get_uint16 ~default:0 x 0
-      let has_implicit_parameters x = 
-        (RA_.has_field x 4)
+      let has_implicit_parameters x =
+        RA_.has_field x 4
       let implicit_parameters_get x = 
-        (RA_.get_struct_list x 4)
+        RA_.get_struct_list x 4
       let implicit_parameters_get_list x =
         Capnp.Array.to_list (implicit_parameters_get x)
       let implicit_parameters_get_array x =
@@ -1945,22 +1746,22 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         RA_.get_uint64 ~default:Uint64.zero x 8
       let param_struct_type_get_int_exn x =
         Capnp.Runtime.Util.int_of_uint64_exn (param_struct_type_get x)
-      let has_param_brand x = 
-        (RA_.has_field x 2)
-      let param_brand_get x = 
-        (RA_.get_struct x 2)
+      let has_param_brand x =
+        RA_.has_field x 2
+      let param_brand_get x =
+        RA_.get_struct x 2
       let result_struct_type_get x =
         RA_.get_uint64 ~default:Uint64.zero x 16
       let result_struct_type_get_int_exn x =
         Capnp.Runtime.Util.int_of_uint64_exn (result_struct_type_get x)
-      let has_result_brand x = 
-        (RA_.has_field x 3)
-      let result_brand_get x = 
-        (RA_.get_struct x 3)
-      let has_annotations x = 
-        (RA_.has_field x 1)
+      let has_result_brand x =
+        RA_.has_field x 3
+      let result_brand_get x =
+        RA_.get_struct x 3
+      let has_annotations x =
+        RA_.has_field x 1
       let annotations_get x = 
-        (RA_.get_struct_list x 1)
+        RA_.get_struct_list x 1
       let annotations_get_list x =
         Capnp.Array.to_list (annotations_get x)
       let annotations_get_array x =
@@ -1969,66 +1770,66 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let of_builder x = Some (RA_.StructStorage.readonly x)
     end
     module Type = struct
-      type t = reader_t_Type_15020482145304562784
-      type builder_t = builder_t_Type_15020482145304562784
+      type struct_t = [`Type_d07378ede1f9cc60]
+      type t = struct_t reader_t
       module List = struct
-        type t = reader_t_List_9792858745991129751
-        type builder_t = builder_t_List_9792858745991129751
-        let has_element_type x = 
-          (RA_.has_field x 0)
-        let element_type_get x = 
-          (RA_.get_struct x 0)
+        type struct_t = [`List_87e739250a60ea97]
+        type t = struct_t reader_t
+        let has_element_type x =
+          RA_.has_field x 0
+        let element_type_get x =
+          RA_.get_struct x 0
         let of_message x = RA_.get_root_struct (RA_.Message.readonly x)
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
       module Enum = struct
-        type t = reader_t_Enum_11389172934837766057
-        type builder_t = builder_t_Enum_11389172934837766057
+        type struct_t = [`Enum_9e0e78711a7f87a9]
+        type t = struct_t reader_t
         let type_id_get x =
           RA_.get_uint64 ~default:Uint64.zero x 8
         let type_id_get_int_exn x =
           Capnp.Runtime.Util.int_of_uint64_exn (type_id_get x)
-        let has_brand x = 
-          (RA_.has_field x 0)
-        let brand_get x = 
-          (RA_.get_struct x 0)
+        let has_brand x =
+          RA_.has_field x 0
+        let brand_get x =
+          RA_.get_struct x 0
         let of_message x = RA_.get_root_struct (RA_.Message.readonly x)
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
       module Struct = struct
-        type t = reader_t_Struct_12410354185295152851
-        type builder_t = builder_t_Struct_12410354185295152851
+        type struct_t = [`Struct_ac3a6f60ef4cc6d3]
+        type t = struct_t reader_t
         let type_id_get x =
           RA_.get_uint64 ~default:Uint64.zero x 8
         let type_id_get_int_exn x =
           Capnp.Runtime.Util.int_of_uint64_exn (type_id_get x)
-        let has_brand x = 
-          (RA_.has_field x 0)
-        let brand_get x = 
-          (RA_.get_struct x 0)
+        let has_brand x =
+          RA_.has_field x 0
+        let brand_get x =
+          RA_.get_struct x 0
         let of_message x = RA_.get_root_struct (RA_.Message.readonly x)
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
       module Interface = struct
-        type t = reader_t_Interface_17116997365232503999
-        type builder_t = builder_t_Interface_17116997365232503999
+        type struct_t = [`Interface_ed8bca69f7fb0cbf]
+        type t = struct_t reader_t
         let type_id_get x =
           RA_.get_uint64 ~default:Uint64.zero x 8
         let type_id_get_int_exn x =
           Capnp.Runtime.Util.int_of_uint64_exn (type_id_get x)
-        let has_brand x = 
-          (RA_.has_field x 0)
-        let brand_get x = 
-          (RA_.get_struct x 0)
+        let has_brand x =
+          RA_.has_field x 0
+        let brand_get x =
+          RA_.get_struct x 0
         let of_message x = RA_.get_root_struct (RA_.Message.readonly x)
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
       module AnyPointer = struct
-        type t = reader_t_AnyPointer_14003731834718800369
-        type builder_t = builder_t_AnyPointer_14003731834718800369
+        type struct_t = [`AnyPointer_c2573fe8a23e49f1]
+        type t = struct_t reader_t
         module Unconstrained = struct
-          type t = reader_t_Unconstrained_10248890354574636630
-          type builder_t = builder_t_Unconstrained_10248890354574636630
+          type struct_t = [`Unconstrained_8e3b5f79fe593656]
+          type t = struct_t reader_t
           let any_kind_get x = ()
           let struct_get x = ()
           let list_get x = ()
@@ -2050,8 +1851,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           let of_builder x = Some (RA_.StructStorage.readonly x)
         end
         module Parameter = struct
-          type t = reader_t_Parameter_11372142272178113157
-          type builder_t = builder_t_Parameter_11372142272178113157
+          type struct_t = [`Parameter_9dd1f724f4614a85]
+          type t = struct_t reader_t
           let scope_id_get x =
             RA_.get_uint64 ~default:Uint64.zero x 16
           let scope_id_get_int_exn x =
@@ -2062,8 +1863,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           let of_builder x = Some (RA_.StructStorage.readonly x)
         end
         module ImplicitMethodParameter = struct
-          type t = reader_t_ImplicitMethodParameter_13470206089842057844
-          type builder_t = builder_t_ImplicitMethodParameter_13470206089842057844
+          type struct_t = [`ImplicitMethodParameter_baefc9120c56e274]
+          type t = struct_t reader_t
           let parameter_index_get x =
             RA_.get_uint16 ~default:0 x 10
           let of_message x = RA_.get_root_struct (RA_.Message.readonly x)
@@ -2152,22 +1953,22 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let of_builder x = Some (RA_.StructStorage.readonly x)
     end
     module Brand = struct
-      type t = reader_t_Brand_10391024731148337707
-      type builder_t = builder_t_Brand_10391024731148337707
+      type struct_t = [`Brand_903455f06065422b]
+      type t = struct_t reader_t
       module Scope = struct
-        type t = reader_t_Scope_12382423449155627977
-        type builder_t = builder_t_Scope_12382423449155627977
-        let has_bind x = 
-          (RA_.has_field x 0)
+        type struct_t = [`Scope_abd73485a9636bc9]
+        type t = struct_t reader_t
+        let has_bind x =
+          RA_.has_field x 0
         let bind_get x = 
-          (RA_.get_struct_list x 0)
+          RA_.get_struct_list x 0
         let bind_get_list x =
           Capnp.Array.to_list (bind_get x)
         let bind_get_array x =
           Capnp.Array.to_array (bind_get x)
         let inherit_get x = ()
         type unnamed_union_t =
-          | Bind of (ro, reader_t_Binding_14439610327179913212, array_t) Capnp.Array.t
+          | Bind of (ro, [`Binding_c863cd16969ee7fc] reader_t, array_t) Capnp.Array.t
           | Inherit
           | Undefined of int
         let get x =
@@ -2183,13 +1984,13 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
       module Binding = struct
-        type t = reader_t_Binding_14439610327179913212
-        type builder_t = builder_t_Binding_14439610327179913212
+        type struct_t = [`Binding_c863cd16969ee7fc]
+        type t = struct_t reader_t
         let unbound_get x = ()
-        let has_type x = 
-          (RA_.has_field x 0)
-        let type_get x = 
-          (RA_.get_struct x 0)
+        let has_type x =
+          RA_.has_field x 0
+        let type_get x =
+          RA_.get_struct x 0
         type unnamed_union_t =
           | Unbound
           | Type of Type.t
@@ -2202,10 +2003,10 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let of_message x = RA_.get_root_struct (RA_.Message.readonly x)
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
-      let has_scopes x = 
-        (RA_.has_field x 0)
+      let has_scopes x =
+        RA_.has_field x 0
       let scopes_get x = 
-        (RA_.get_struct_list x 0)
+        RA_.get_struct_list x 0
       let scopes_get_list x =
         Capnp.Array.to_list (scopes_get x)
       let scopes_get_array x =
@@ -2214,8 +2015,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let of_builder x = Some (RA_.StructStorage.readonly x)
     end
     module Value = struct
-      type t = reader_t_Value_14853958794117909659
-      type builder_t = builder_t_Value_14853958794117909659
+      type struct_t = [`Value_ce23dcd2d7b00c9b]
+      type t = struct_t reader_t
       let void_get x = ()
       let bool_get x =
         RA_.get_bit ~default:false x ~byte_ofs:2 ~bit_ofs:0
@@ -2317,20 +2118,20 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let of_builder x = Some (RA_.StructStorage.readonly x)
     end
     module Annotation = struct
-      type t = reader_t_Annotation_17422339044421236034
-      type builder_t = builder_t_Annotation_17422339044421236034
+      type struct_t = [`Annotation_f1c8950dab257542]
+      type t = struct_t reader_t
       let id_get x =
         RA_.get_uint64 ~default:Uint64.zero x 0
       let id_get_int_exn x =
         Capnp.Runtime.Util.int_of_uint64_exn (id_get x)
-      let has_brand x = 
-        (RA_.has_field x 1)
-      let brand_get x = 
-        (RA_.get_struct x 1)
-      let has_value x = 
-        (RA_.has_field x 0)
-      let value_get x = 
-        (RA_.get_struct x 0)
+      let has_brand x =
+        RA_.has_field x 1
+      let brand_get x =
+        RA_.get_struct x 1
+      let has_value x =
+        RA_.has_field x 0
+      let value_get x =
+        RA_.get_struct x 0
       let of_message x = RA_.get_root_struct (RA_.Message.readonly x)
       let of_builder x = Some (RA_.StructStorage.readonly x)
     end
@@ -2347,8 +2148,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         | Undefined of int
     end
     module CapnpVersion = struct
-      type t = reader_t_CapnpVersion_15590670654532458851
-      type builder_t = builder_t_CapnpVersion_15590670654532458851
+      type struct_t = [`CapnpVersion_d85d305b7d839963]
+      type t = struct_t reader_t
       let major_get x =
         RA_.get_uint16 ~default:0 x 0
       let minor_get x =
@@ -2359,14 +2160,14 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let of_builder x = Some (RA_.StructStorage.readonly x)
     end
     module CodeGeneratorRequest = struct
-      type t = reader_t_CodeGeneratorRequest_13818529054586492878
-      type builder_t = builder_t_CodeGeneratorRequest_13818529054586492878
+      type struct_t = [`CodeGeneratorRequest_bfc546f6210ad7ce]
+      type t = struct_t reader_t
       module RequestedFile = struct
-        type t = reader_t_RequestedFile_14981803260258615394
-        type builder_t = builder_t_RequestedFile_14981803260258615394
+        type struct_t = [`RequestedFile_cfea0eb02e810062]
+        type t = struct_t reader_t
         module Import = struct
-          type t = reader_t_Import_12560611460656617445
-          type builder_t = builder_t_Import_12560611460656617445
+          type struct_t = [`Import_ae504193122357e5]
+          type t = struct_t reader_t
           let id_get x =
             RA_.get_uint64 ~default:Uint64.zero x 0
           let id_get_int_exn x =
@@ -2386,10 +2187,10 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           RA_.has_field x 0
         let filename_get x =
           RA_.get_text ~default:"" x 0
-        let has_imports x = 
-          (RA_.has_field x 1)
+        let has_imports x =
+          RA_.has_field x 1
         let imports_get x = 
-          (RA_.get_struct_list x 1)
+          RA_.get_struct_list x 1
         let imports_get_list x =
           Capnp.Array.to_list (imports_get x)
         let imports_get_array x =
@@ -2397,22 +2198,22 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let of_message x = RA_.get_root_struct (RA_.Message.readonly x)
         let of_builder x = Some (RA_.StructStorage.readonly x)
       end
-      let has_capnp_version x = 
-        (RA_.has_field x 2)
-      let capnp_version_get x = 
-        (RA_.get_struct x 2)
-      let has_nodes x = 
-        (RA_.has_field x 0)
+      let has_capnp_version x =
+        RA_.has_field x 2
+      let capnp_version_get x =
+        RA_.get_struct x 2
+      let has_nodes x =
+        RA_.has_field x 0
       let nodes_get x = 
-        (RA_.get_struct_list x 0)
+        RA_.get_struct_list x 0
       let nodes_get_list x =
         Capnp.Array.to_list (nodes_get x)
       let nodes_get_array x =
         Capnp.Array.to_array (nodes_get x)
-      let has_requested_files x = 
-        (RA_.has_field x 1)
+      let has_requested_files x =
+        RA_.has_field x 1
       let requested_files_get x = 
-        (RA_.get_struct_list x 1)
+        RA_.get_struct_list x 1
       let requested_files_get_list x =
         Capnp.Array.to_list (requested_files_get x)
       let requested_files_get_array x =
@@ -2428,11 +2229,11 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
     type pointer_t = rw MessageWrapper.Slice.t
 
     module Node = struct
-      type t = builder_t_Node_16610026722781537303
-      type reader_t = reader_t_Node_16610026722781537303
+      type struct_t = [`Node_e682ab4cf923a417]
+      type t = struct_t builder_t
       module Struct = struct
-        type t = builder_t_Struct_11430331134483579957
-        type reader_t = reader_t_Struct_11430331134483579957
+        type struct_t = [`Struct_9ea0b19b37fb4435]
+        type t = struct_t builder_t
         let data_word_count_get x =
           BA_.get_uint16 ~default:0 x 14
         let data_word_count_set_exn x v =
@@ -2463,18 +2264,18 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let discriminant_offset_set x v =
           BA_.set_uint32 ~default:Uint32.zero x 32 v
         let discriminant_offset_set_int_exn x v = discriminant_offset_set x (Capnp.Runtime.Util.uint32_of_int_exn v)
-        let has_fields x = 
-          (BA_.has_field x 3)
+        let has_fields x =
+          BA_.has_field x 3
         let fields_get x = 
-          (BA_.get_struct_list ~data_words:3 ~pointer_words:4 x 3)
+          BA_.get_struct_list ~data_words:3 ~pointer_words:4 x 3
         let fields_get_list x =
           Capnp.Array.to_list (fields_get x)
         let fields_get_array x =
           Capnp.Array.to_array (fields_get x)
-        let fields_set x v = 
-          (BA_.set_struct_list ~data_words:3 ~pointer_words:4 x 3 (v))
-        let fields_init x n = 
-          (BA_.init_struct_list ~data_words:3 ~pointer_words:4 x 3 n)
+        let fields_set x v =
+          BA_.set_struct_list ~data_words:3 ~pointer_words:4 x 3 v
+        let fields_init x n =
+          BA_.init_struct_list ~data_words:3 ~pointer_words:4 x 3 n
         let fields_set_list x v =
           let builder = fields_init x (List.length v) in
           let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -2492,20 +2293,20 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           BA_.init_struct_pointer ptr ~data_words:5 ~pointer_words:6
       end
       module Enum = struct
-        type t = builder_t_Enum_13063450714778629528
-        type reader_t = reader_t_Enum_13063450714778629528
-        let has_enumerants x = 
-          (BA_.has_field x 3)
+        type struct_t = [`Enum_b54ab3364333f598]
+        type t = struct_t builder_t
+        let has_enumerants x =
+          BA_.has_field x 3
         let enumerants_get x = 
-          (BA_.get_struct_list ~data_words:1 ~pointer_words:2 x 3)
+          BA_.get_struct_list ~data_words:1 ~pointer_words:2 x 3
         let enumerants_get_list x =
           Capnp.Array.to_list (enumerants_get x)
         let enumerants_get_array x =
           Capnp.Array.to_array (enumerants_get x)
-        let enumerants_set x v = 
-          (BA_.set_struct_list ~data_words:1 ~pointer_words:2 x 3 (v))
-        let enumerants_init x n = 
-          (BA_.init_struct_list ~data_words:1 ~pointer_words:2 x 3 n)
+        let enumerants_set x v =
+          BA_.set_struct_list ~data_words:1 ~pointer_words:2 x 3 v
+        let enumerants_init x n =
+          BA_.init_struct_list ~data_words:1 ~pointer_words:2 x 3 n
         let enumerants_set_list x v =
           let builder = enumerants_init x (List.length v) in
           let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -2523,20 +2324,20 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           BA_.init_struct_pointer ptr ~data_words:5 ~pointer_words:6
       end
       module Interface = struct
-        type t = builder_t_Interface_16728431493453586831
-        type reader_t = reader_t_Interface_16728431493453586831
-        let has_methods x = 
-          (BA_.has_field x 3)
+        type struct_t = [`Interface_e82753cff0c2218f]
+        type t = struct_t builder_t
+        let has_methods x =
+          BA_.has_field x 3
         let methods_get x = 
-          (BA_.get_struct_list ~data_words:3 ~pointer_words:5 x 3)
+          BA_.get_struct_list ~data_words:3 ~pointer_words:5 x 3
         let methods_get_list x =
           Capnp.Array.to_list (methods_get x)
         let methods_get_array x =
           Capnp.Array.to_array (methods_get x)
-        let methods_set x v = 
-          (BA_.set_struct_list ~data_words:3 ~pointer_words:5 x 3 (v))
-        let methods_init x n = 
-          (BA_.init_struct_list ~data_words:3 ~pointer_words:5 x 3 n)
+        let methods_set x v =
+          BA_.set_struct_list ~data_words:3 ~pointer_words:5 x 3 v
+        let methods_init x n =
+          BA_.init_struct_list ~data_words:3 ~pointer_words:5 x 3 n
         let methods_set_list x v =
           let builder = methods_init x (List.length v) in
           let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -2545,18 +2346,18 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           let builder = methods_init x (Array.length v) in
           let () = Array.iteri (fun i a -> Capnp.Array.set builder i a) v in
           builder
-        let has_superclasses x = 
-          (BA_.has_field x 4)
+        let has_superclasses x =
+          BA_.has_field x 4
         let superclasses_get x = 
-          (BA_.get_struct_list ~data_words:1 ~pointer_words:1 x 4)
+          BA_.get_struct_list ~data_words:1 ~pointer_words:1 x 4
         let superclasses_get_list x =
           Capnp.Array.to_list (superclasses_get x)
         let superclasses_get_array x =
           Capnp.Array.to_array (superclasses_get x)
-        let superclasses_set x v = 
-          (BA_.set_struct_list ~data_words:1 ~pointer_words:1 x 4 (v))
-        let superclasses_init x n = 
-          (BA_.init_struct_list ~data_words:1 ~pointer_words:1 x 4 n)
+        let superclasses_set x v =
+          BA_.set_struct_list ~data_words:1 ~pointer_words:1 x 4 v
+        let superclasses_init x n =
+          BA_.init_struct_list ~data_words:1 ~pointer_words:1 x 4 n
         let superclasses_set_list x v =
           let builder = superclasses_init x (List.length v) in
           let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -2574,28 +2375,28 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           BA_.init_struct_pointer ptr ~data_words:5 ~pointer_words:6
       end
       module Const = struct
-        type t = builder_t_Const_12793219851699983392
-        type reader_t = reader_t_Const_12793219851699983392
-        let has_type x = 
-          (BA_.has_field x 3)
-        let type_get x = 
-          (BA_.get_struct ~data_words:3 ~pointer_words:1 x 3)
-        let type_set_reader x v = 
-          (BA_.set_struct ~data_words:3 ~pointer_words:1 x 3 (v))
-        let type_set_builder x v = 
-          (BA_.set_struct ~data_words:3 ~pointer_words:1 x 3 (Some (v)))
-        let type_init x = 
-          (BA_.init_struct ~data_words:3 ~pointer_words:1 x 3)
-        let has_value x = 
-          (BA_.has_field x 4)
-        let value_get x = 
-          (BA_.get_struct ~data_words:2 ~pointer_words:1 x 4)
-        let value_set_reader x v = 
-          (BA_.set_struct ~data_words:2 ~pointer_words:1 x 4 (v))
-        let value_set_builder x v = 
-          (BA_.set_struct ~data_words:2 ~pointer_words:1 x 4 (Some (v)))
-        let value_init x = 
-          (BA_.init_struct ~data_words:2 ~pointer_words:1 x 4)
+        type struct_t = [`Const_b18aa5ac7a0d9420]
+        type t = struct_t builder_t
+        let has_type x =
+          BA_.has_field x 3
+        let type_get x =
+          BA_.get_struct ~data_words:3 ~pointer_words:1 x 3
+        let type_set_reader x v =
+          BA_.set_struct ~data_words:3 ~pointer_words:1 x 3 v
+        let type_set_builder x v =
+          BA_.set_struct ~data_words:3 ~pointer_words:1 x 3 (Some v)
+        let type_init x =
+          BA_.init_struct ~data_words:3 ~pointer_words:1 x 3
+        let has_value x =
+          BA_.has_field x 4
+        let value_get x =
+          BA_.get_struct ~data_words:2 ~pointer_words:1 x 4
+        let value_set_reader x v =
+          BA_.set_struct ~data_words:2 ~pointer_words:1 x 4 v
+        let value_set_builder x v =
+          BA_.set_struct ~data_words:2 ~pointer_words:1 x 4 (Some v)
+        let value_init x =
+          BA_.init_struct ~data_words:2 ~pointer_words:1 x 4
         let of_message x = BA_.get_root_struct ~data_words:5 ~pointer_words:6 x
         let to_message x = x.BA_.NM.StructStorage.data.MessageWrapper.Slice.msg
         let to_reader x = Some (RA_.StructStorage.readonly x)
@@ -2605,18 +2406,18 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           BA_.init_struct_pointer ptr ~data_words:5 ~pointer_words:6
       end
       module Annotation = struct
-        type t = builder_t_Annotation_17011813041836786320
-        type reader_t = reader_t_Annotation_17011813041836786320
-        let has_type x = 
-          (BA_.has_field x 3)
-        let type_get x = 
-          (BA_.get_struct ~data_words:3 ~pointer_words:1 x 3)
-        let type_set_reader x v = 
-          (BA_.set_struct ~data_words:3 ~pointer_words:1 x 3 (v))
-        let type_set_builder x v = 
-          (BA_.set_struct ~data_words:3 ~pointer_words:1 x 3 (Some (v)))
-        let type_init x = 
-          (BA_.init_struct ~data_words:3 ~pointer_words:1 x 3)
+        type struct_t = [`Annotation_ec1619d4400a0290]
+        type t = struct_t builder_t
+        let has_type x =
+          BA_.has_field x 3
+        let type_get x =
+          BA_.get_struct ~data_words:3 ~pointer_words:1 x 3
+        let type_set_reader x v =
+          BA_.set_struct ~data_words:3 ~pointer_words:1 x 3 v
+        let type_set_builder x v =
+          BA_.set_struct ~data_words:3 ~pointer_words:1 x 3 (Some v)
+        let type_init x =
+          BA_.init_struct ~data_words:3 ~pointer_words:1 x 3
         let targets_file_get x =
           BA_.get_bit ~default:false x ~byte_ofs:14 ~bit_ofs:0
         let targets_file_set x v =
@@ -2674,8 +2475,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           BA_.init_struct_pointer ptr ~data_words:5 ~pointer_words:6
       end
       module Parameter = struct
-        type t = builder_t_Parameter_13353766412138554289
-        type reader_t = reader_t_Parameter_13353766412138554289
+        type struct_t = [`Parameter_b9521bccf10fa3b1]
+        type t = struct_t builder_t
         let has_name x =
           BA_.has_field x 0
         let name_get x =
@@ -2691,8 +2492,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           BA_.init_struct_pointer ptr ~data_words:0 ~pointer_words:1
       end
       module NestedNode = struct
-        type t = builder_t_NestedNode_16050641862814319170
-        type reader_t = reader_t_NestedNode_16050641862814319170
+        type struct_t = [`NestedNode_debf55bbfa0fc242]
+        type t = struct_t builder_t
         let has_name x =
           BA_.has_field x 0
         let name_get x =
@@ -2892,18 +2693,18 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let scope_id_set x v =
         BA_.set_uint64 ~default:Uint64.zero x 16 v
       let scope_id_set_int_exn x v = scope_id_set x (Capnp.Runtime.Util.uint64_of_int_exn v)
-      let has_parameters x = 
-        (BA_.has_field x 5)
+      let has_parameters x =
+        BA_.has_field x 5
       let parameters_get x = 
-        (BA_.get_struct_list ~data_words:0 ~pointer_words:1 x 5)
+        BA_.get_struct_list ~data_words:0 ~pointer_words:1 x 5
       let parameters_get_list x =
         Capnp.Array.to_list (parameters_get x)
       let parameters_get_array x =
         Capnp.Array.to_array (parameters_get x)
-      let parameters_set x v = 
-        (BA_.set_struct_list ~data_words:0 ~pointer_words:1 x 5 (v))
-      let parameters_init x n = 
-        (BA_.init_struct_list ~data_words:0 ~pointer_words:1 x 5 n)
+      let parameters_set x v =
+        BA_.set_struct_list ~data_words:0 ~pointer_words:1 x 5 v
+      let parameters_init x n =
+        BA_.init_struct_list ~data_words:0 ~pointer_words:1 x 5 n
       let parameters_set_list x v =
         let builder = parameters_init x (List.length v) in
         let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -2916,18 +2717,18 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         BA_.get_bit ~default:false x ~byte_ofs:36 ~bit_ofs:0
       let is_generic_set x v =
         BA_.set_bit ~default:false x ~byte_ofs:36 ~bit_ofs:0 v
-      let has_nested_nodes x = 
-        (BA_.has_field x 1)
+      let has_nested_nodes x =
+        BA_.has_field x 1
       let nested_nodes_get x = 
-        (BA_.get_struct_list ~data_words:1 ~pointer_words:1 x 1)
+        BA_.get_struct_list ~data_words:1 ~pointer_words:1 x 1
       let nested_nodes_get_list x =
         Capnp.Array.to_list (nested_nodes_get x)
       let nested_nodes_get_array x =
         Capnp.Array.to_array (nested_nodes_get x)
-      let nested_nodes_set x v = 
-        (BA_.set_struct_list ~data_words:1 ~pointer_words:1 x 1 (v))
-      let nested_nodes_init x n = 
-        (BA_.init_struct_list ~data_words:1 ~pointer_words:1 x 1 n)
+      let nested_nodes_set x v =
+        BA_.set_struct_list ~data_words:1 ~pointer_words:1 x 1 v
+      let nested_nodes_init x n =
+        BA_.init_struct_list ~data_words:1 ~pointer_words:1 x 1 n
       let nested_nodes_set_list x v =
         let builder = nested_nodes_init x (List.length v) in
         let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -2936,18 +2737,18 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let builder = nested_nodes_init x (Array.length v) in
         let () = Array.iteri (fun i a -> Capnp.Array.set builder i a) v in
         builder
-      let has_annotations x = 
-        (BA_.has_field x 2)
+      let has_annotations x =
+        BA_.has_field x 2
       let annotations_get x = 
-        (BA_.get_struct_list ~data_words:1 ~pointer_words:2 x 2)
+        BA_.get_struct_list ~data_words:1 ~pointer_words:2 x 2
       let annotations_get_list x =
         Capnp.Array.to_list (annotations_get x)
       let annotations_get_array x =
         Capnp.Array.to_array (annotations_get x)
-      let annotations_set x v = 
-        (BA_.set_struct_list ~data_words:1 ~pointer_words:2 x 2 (v))
-      let annotations_init x n = 
-        (BA_.init_struct_list ~data_words:1 ~pointer_words:2 x 2 n)
+      let annotations_set x v =
+        BA_.set_struct_list ~data_words:1 ~pointer_words:2 x 2 v
+      let annotations_init x n =
+        BA_.init_struct_list ~data_words:1 ~pointer_words:2 x 2 n
       let annotations_set_list x v =
         let builder = annotations_init x (List.length v) in
         let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -2965,11 +2766,11 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         BA_.init_struct_pointer ptr ~data_words:5 ~pointer_words:6
     end
     module Field = struct
-      type t = builder_t_Field_11145653318641710175
-      type reader_t = reader_t_Field_11145653318641710175
+      type struct_t = [`Field_9aad50a41f4af45f]
+      type t = struct_t builder_t
       module Slot = struct
-        type t = builder_t_Slot_14133145859926553711
-        type reader_t = reader_t_Slot_14133145859926553711
+        type struct_t = [`Slot_c42305476bb4746f]
+        type t = struct_t builder_t
         let offset_get x =
           BA_.get_uint32 ~default:Uint32.zero x 4
         let offset_get_int_exn x =
@@ -2977,26 +2778,26 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let offset_set x v =
           BA_.set_uint32 ~default:Uint32.zero x 4 v
         let offset_set_int_exn x v = offset_set x (Capnp.Runtime.Util.uint32_of_int_exn v)
-        let has_type x = 
-          (BA_.has_field x 2)
-        let type_get x = 
-          (BA_.get_struct ~data_words:3 ~pointer_words:1 x 2)
-        let type_set_reader x v = 
-          (BA_.set_struct ~data_words:3 ~pointer_words:1 x 2 (v))
-        let type_set_builder x v = 
-          (BA_.set_struct ~data_words:3 ~pointer_words:1 x 2 (Some (v)))
-        let type_init x = 
-          (BA_.init_struct ~data_words:3 ~pointer_words:1 x 2)
-        let has_default_value x = 
-          (BA_.has_field x 3)
-        let default_value_get x = 
-          (BA_.get_struct ~data_words:2 ~pointer_words:1 x 3)
-        let default_value_set_reader x v = 
-          (BA_.set_struct ~data_words:2 ~pointer_words:1 x 3 (v))
-        let default_value_set_builder x v = 
-          (BA_.set_struct ~data_words:2 ~pointer_words:1 x 3 (Some (v)))
-        let default_value_init x = 
-          (BA_.init_struct ~data_words:2 ~pointer_words:1 x 3)
+        let has_type x =
+          BA_.has_field x 2
+        let type_get x =
+          BA_.get_struct ~data_words:3 ~pointer_words:1 x 2
+        let type_set_reader x v =
+          BA_.set_struct ~data_words:3 ~pointer_words:1 x 2 v
+        let type_set_builder x v =
+          BA_.set_struct ~data_words:3 ~pointer_words:1 x 2 (Some v)
+        let type_init x =
+          BA_.init_struct ~data_words:3 ~pointer_words:1 x 2
+        let has_default_value x =
+          BA_.has_field x 3
+        let default_value_get x =
+          BA_.get_struct ~data_words:2 ~pointer_words:1 x 3
+        let default_value_set_reader x v =
+          BA_.set_struct ~data_words:2 ~pointer_words:1 x 3 v
+        let default_value_set_builder x v =
+          BA_.set_struct ~data_words:2 ~pointer_words:1 x 3 (Some v)
+        let default_value_init x =
+          BA_.init_struct ~data_words:2 ~pointer_words:1 x 3
         let had_explicit_default_get x =
           BA_.get_bit ~default:false x ~byte_ofs:16 ~bit_ofs:0
         let had_explicit_default_set x v =
@@ -3010,8 +2811,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           BA_.init_struct_pointer ptr ~data_words:3 ~pointer_words:4
       end
       module Group = struct
-        type t = builder_t_Group_14626792032033250577
-        type reader_t = reader_t_Group_14626792032033250577
+        type struct_t = [`Group_cafccddb68db1d11]
+        type t = struct_t builder_t
         let type_id_get x =
           BA_.get_uint64 ~default:Uint64.zero x 16
         let type_id_get_int_exn x =
@@ -3028,8 +2829,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           BA_.init_struct_pointer ptr ~data_words:3 ~pointer_words:4
       end
       module Ordinal = struct
-        type t = builder_t_Ordinal_13515537513213004774
-        type reader_t = reader_t_Ordinal_13515537513213004774
+        type struct_t = [`Ordinal_bb90d5c287870be6]
+        type t = struct_t builder_t
         let implicit_get x = ()
         let implicit_set x =
           BA_.set_void ~discr:{BA_.Discr.value=0; BA_.Discr.byte_ofs=10} x
@@ -3116,18 +2917,18 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         BA_.get_uint16 ~default:0 x 0
       let code_order_set_exn x v =
         BA_.set_uint16 ~default:0 x 0 v
-      let has_annotations x = 
-        (BA_.has_field x 1)
+      let has_annotations x =
+        BA_.has_field x 1
       let annotations_get x = 
-        (BA_.get_struct_list ~data_words:1 ~pointer_words:2 x 1)
+        BA_.get_struct_list ~data_words:1 ~pointer_words:2 x 1
       let annotations_get_list x =
         Capnp.Array.to_list (annotations_get x)
       let annotations_get_array x =
         Capnp.Array.to_array (annotations_get x)
-      let annotations_set x v = 
-        (BA_.set_struct_list ~data_words:1 ~pointer_words:2 x 1 (v))
-      let annotations_init x n = 
-        (BA_.init_struct_list ~data_words:1 ~pointer_words:2 x 1 n)
+      let annotations_set x v =
+        BA_.set_struct_list ~data_words:1 ~pointer_words:2 x 1 v
+      let annotations_init x n =
+        BA_.init_struct_list ~data_words:1 ~pointer_words:2 x 1 n
       let annotations_set_list x v =
         let builder = annotations_init x (List.length v) in
         let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -3158,8 +2959,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         BA_.init_struct_pointer ptr ~data_words:3 ~pointer_words:4
     end
     module Enumerant = struct
-      type t = builder_t_Enumerant_10919677598968879693
-      type reader_t = reader_t_Enumerant_10919677598968879693
+      type struct_t = [`Enumerant_978a7cebdc549a4d]
+      type t = struct_t builder_t
       let has_name x =
         BA_.has_field x 0
       let name_get x =
@@ -3170,18 +2971,18 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         BA_.get_uint16 ~default:0 x 0
       let code_order_set_exn x v =
         BA_.set_uint16 ~default:0 x 0 v
-      let has_annotations x = 
-        (BA_.has_field x 1)
+      let has_annotations x =
+        BA_.has_field x 1
       let annotations_get x = 
-        (BA_.get_struct_list ~data_words:1 ~pointer_words:2 x 1)
+        BA_.get_struct_list ~data_words:1 ~pointer_words:2 x 1
       let annotations_get_list x =
         Capnp.Array.to_list (annotations_get x)
       let annotations_get_array x =
         Capnp.Array.to_array (annotations_get x)
-      let annotations_set x v = 
-        (BA_.set_struct_list ~data_words:1 ~pointer_words:2 x 1 (v))
-      let annotations_init x n = 
-        (BA_.init_struct_list ~data_words:1 ~pointer_words:2 x 1 n)
+      let annotations_set x v =
+        BA_.set_struct_list ~data_words:1 ~pointer_words:2 x 1 v
+      let annotations_init x n =
+        BA_.init_struct_list ~data_words:1 ~pointer_words:2 x 1 n
       let annotations_set_list x v =
         let builder = annotations_init x (List.length v) in
         let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -3199,8 +3000,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         BA_.init_struct_pointer ptr ~data_words:1 ~pointer_words:2
     end
     module Superclass = struct
-      type t = builder_t_Superclass_12220001500510083064
-      type reader_t = reader_t_Superclass_12220001500510083064
+      type struct_t = [`Superclass_a9962a9ed0a4d7f8]
+      type t = struct_t builder_t
       let id_get x =
         BA_.get_uint64 ~default:Uint64.zero x 0
       let id_get_int_exn x =
@@ -3208,16 +3009,16 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let id_set x v =
         BA_.set_uint64 ~default:Uint64.zero x 0 v
       let id_set_int_exn x v = id_set x (Capnp.Runtime.Util.uint64_of_int_exn v)
-      let has_brand x = 
-        (BA_.has_field x 0)
-      let brand_get x = 
-        (BA_.get_struct ~data_words:0 ~pointer_words:1 x 0)
-      let brand_set_reader x v = 
-        (BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 (v))
-      let brand_set_builder x v = 
-        (BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 (Some (v)))
-      let brand_init x = 
-        (BA_.init_struct ~data_words:0 ~pointer_words:1 x 0)
+      let has_brand x =
+        BA_.has_field x 0
+      let brand_get x =
+        BA_.get_struct ~data_words:0 ~pointer_words:1 x 0
+      let brand_set_reader x v =
+        BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 v
+      let brand_set_builder x v =
+        BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 (Some v)
+      let brand_init x =
+        BA_.init_struct ~data_words:0 ~pointer_words:1 x 0
       let of_message x = BA_.get_root_struct ~data_words:1 ~pointer_words:1 x
       let to_message x = x.BA_.NM.StructStorage.data.MessageWrapper.Slice.msg
       let to_reader x = Some (RA_.StructStorage.readonly x)
@@ -3227,8 +3028,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         BA_.init_struct_pointer ptr ~data_words:1 ~pointer_words:1
     end
     module Method = struct
-      type t = builder_t_Method_10736806783679155584
-      type reader_t = reader_t_Method_10736806783679155584
+      type struct_t = [`Method_9500cce23b334d80]
+      type t = struct_t builder_t
       let has_name x =
         BA_.has_field x 0
       let name_get x =
@@ -3239,18 +3040,18 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         BA_.get_uint16 ~default:0 x 0
       let code_order_set_exn x v =
         BA_.set_uint16 ~default:0 x 0 v
-      let has_implicit_parameters x = 
-        (BA_.has_field x 4)
+      let has_implicit_parameters x =
+        BA_.has_field x 4
       let implicit_parameters_get x = 
-        (BA_.get_struct_list ~data_words:0 ~pointer_words:1 x 4)
+        BA_.get_struct_list ~data_words:0 ~pointer_words:1 x 4
       let implicit_parameters_get_list x =
         Capnp.Array.to_list (implicit_parameters_get x)
       let implicit_parameters_get_array x =
         Capnp.Array.to_array (implicit_parameters_get x)
-      let implicit_parameters_set x v = 
-        (BA_.set_struct_list ~data_words:0 ~pointer_words:1 x 4 (v))
-      let implicit_parameters_init x n = 
-        (BA_.init_struct_list ~data_words:0 ~pointer_words:1 x 4 n)
+      let implicit_parameters_set x v =
+        BA_.set_struct_list ~data_words:0 ~pointer_words:1 x 4 v
+      let implicit_parameters_init x n =
+        BA_.init_struct_list ~data_words:0 ~pointer_words:1 x 4 n
       let implicit_parameters_set_list x v =
         let builder = implicit_parameters_init x (List.length v) in
         let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -3266,16 +3067,16 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let param_struct_type_set x v =
         BA_.set_uint64 ~default:Uint64.zero x 8 v
       let param_struct_type_set_int_exn x v = param_struct_type_set x (Capnp.Runtime.Util.uint64_of_int_exn v)
-      let has_param_brand x = 
-        (BA_.has_field x 2)
-      let param_brand_get x = 
-        (BA_.get_struct ~data_words:0 ~pointer_words:1 x 2)
-      let param_brand_set_reader x v = 
-        (BA_.set_struct ~data_words:0 ~pointer_words:1 x 2 (v))
-      let param_brand_set_builder x v = 
-        (BA_.set_struct ~data_words:0 ~pointer_words:1 x 2 (Some (v)))
-      let param_brand_init x = 
-        (BA_.init_struct ~data_words:0 ~pointer_words:1 x 2)
+      let has_param_brand x =
+        BA_.has_field x 2
+      let param_brand_get x =
+        BA_.get_struct ~data_words:0 ~pointer_words:1 x 2
+      let param_brand_set_reader x v =
+        BA_.set_struct ~data_words:0 ~pointer_words:1 x 2 v
+      let param_brand_set_builder x v =
+        BA_.set_struct ~data_words:0 ~pointer_words:1 x 2 (Some v)
+      let param_brand_init x =
+        BA_.init_struct ~data_words:0 ~pointer_words:1 x 2
       let result_struct_type_get x =
         BA_.get_uint64 ~default:Uint64.zero x 16
       let result_struct_type_get_int_exn x =
@@ -3283,28 +3084,28 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let result_struct_type_set x v =
         BA_.set_uint64 ~default:Uint64.zero x 16 v
       let result_struct_type_set_int_exn x v = result_struct_type_set x (Capnp.Runtime.Util.uint64_of_int_exn v)
-      let has_result_brand x = 
-        (BA_.has_field x 3)
-      let result_brand_get x = 
-        (BA_.get_struct ~data_words:0 ~pointer_words:1 x 3)
-      let result_brand_set_reader x v = 
-        (BA_.set_struct ~data_words:0 ~pointer_words:1 x 3 (v))
-      let result_brand_set_builder x v = 
-        (BA_.set_struct ~data_words:0 ~pointer_words:1 x 3 (Some (v)))
-      let result_brand_init x = 
-        (BA_.init_struct ~data_words:0 ~pointer_words:1 x 3)
-      let has_annotations x = 
-        (BA_.has_field x 1)
+      let has_result_brand x =
+        BA_.has_field x 3
+      let result_brand_get x =
+        BA_.get_struct ~data_words:0 ~pointer_words:1 x 3
+      let result_brand_set_reader x v =
+        BA_.set_struct ~data_words:0 ~pointer_words:1 x 3 v
+      let result_brand_set_builder x v =
+        BA_.set_struct ~data_words:0 ~pointer_words:1 x 3 (Some v)
+      let result_brand_init x =
+        BA_.init_struct ~data_words:0 ~pointer_words:1 x 3
+      let has_annotations x =
+        BA_.has_field x 1
       let annotations_get x = 
-        (BA_.get_struct_list ~data_words:1 ~pointer_words:2 x 1)
+        BA_.get_struct_list ~data_words:1 ~pointer_words:2 x 1
       let annotations_get_list x =
         Capnp.Array.to_list (annotations_get x)
       let annotations_get_array x =
         Capnp.Array.to_array (annotations_get x)
-      let annotations_set x v = 
-        (BA_.set_struct_list ~data_words:1 ~pointer_words:2 x 1 (v))
-      let annotations_init x n = 
-        (BA_.init_struct_list ~data_words:1 ~pointer_words:2 x 1 n)
+      let annotations_set x v =
+        BA_.set_struct_list ~data_words:1 ~pointer_words:2 x 1 v
+      let annotations_init x n =
+        BA_.init_struct_list ~data_words:1 ~pointer_words:2 x 1 n
       let annotations_set_list x v =
         let builder = annotations_init x (List.length v) in
         let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -3322,21 +3123,21 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         BA_.init_struct_pointer ptr ~data_words:3 ~pointer_words:5
     end
     module Type = struct
-      type t = builder_t_Type_15020482145304562784
-      type reader_t = reader_t_Type_15020482145304562784
+      type struct_t = [`Type_d07378ede1f9cc60]
+      type t = struct_t builder_t
       module List = struct
-        type t = builder_t_List_9792858745991129751
-        type reader_t = reader_t_List_9792858745991129751
-        let has_element_type x = 
-          (BA_.has_field x 0)
-        let element_type_get x = 
-          (BA_.get_struct ~data_words:3 ~pointer_words:1 x 0)
-        let element_type_set_reader x v = 
-          (BA_.set_struct ~data_words:3 ~pointer_words:1 x 0 (v))
-        let element_type_set_builder x v = 
-          (BA_.set_struct ~data_words:3 ~pointer_words:1 x 0 (Some (v)))
-        let element_type_init x = 
-          (BA_.init_struct ~data_words:3 ~pointer_words:1 x 0)
+        type struct_t = [`List_87e739250a60ea97]
+        type t = struct_t builder_t
+        let has_element_type x =
+          BA_.has_field x 0
+        let element_type_get x =
+          BA_.get_struct ~data_words:3 ~pointer_words:1 x 0
+        let element_type_set_reader x v =
+          BA_.set_struct ~data_words:3 ~pointer_words:1 x 0 v
+        let element_type_set_builder x v =
+          BA_.set_struct ~data_words:3 ~pointer_words:1 x 0 (Some v)
+        let element_type_init x =
+          BA_.init_struct ~data_words:3 ~pointer_words:1 x 0
         let of_message x = BA_.get_root_struct ~data_words:3 ~pointer_words:1 x
         let to_message x = x.BA_.NM.StructStorage.data.MessageWrapper.Slice.msg
         let to_reader x = Some (RA_.StructStorage.readonly x)
@@ -3346,8 +3147,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           BA_.init_struct_pointer ptr ~data_words:3 ~pointer_words:1
       end
       module Enum = struct
-        type t = builder_t_Enum_11389172934837766057
-        type reader_t = reader_t_Enum_11389172934837766057
+        type struct_t = [`Enum_9e0e78711a7f87a9]
+        type t = struct_t builder_t
         let type_id_get x =
           BA_.get_uint64 ~default:Uint64.zero x 8
         let type_id_get_int_exn x =
@@ -3355,16 +3156,16 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let type_id_set x v =
           BA_.set_uint64 ~default:Uint64.zero x 8 v
         let type_id_set_int_exn x v = type_id_set x (Capnp.Runtime.Util.uint64_of_int_exn v)
-        let has_brand x = 
-          (BA_.has_field x 0)
-        let brand_get x = 
-          (BA_.get_struct ~data_words:0 ~pointer_words:1 x 0)
-        let brand_set_reader x v = 
-          (BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 (v))
-        let brand_set_builder x v = 
-          (BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 (Some (v)))
-        let brand_init x = 
-          (BA_.init_struct ~data_words:0 ~pointer_words:1 x 0)
+        let has_brand x =
+          BA_.has_field x 0
+        let brand_get x =
+          BA_.get_struct ~data_words:0 ~pointer_words:1 x 0
+        let brand_set_reader x v =
+          BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 v
+        let brand_set_builder x v =
+          BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 (Some v)
+        let brand_init x =
+          BA_.init_struct ~data_words:0 ~pointer_words:1 x 0
         let of_message x = BA_.get_root_struct ~data_words:3 ~pointer_words:1 x
         let to_message x = x.BA_.NM.StructStorage.data.MessageWrapper.Slice.msg
         let to_reader x = Some (RA_.StructStorage.readonly x)
@@ -3374,8 +3175,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           BA_.init_struct_pointer ptr ~data_words:3 ~pointer_words:1
       end
       module Struct = struct
-        type t = builder_t_Struct_12410354185295152851
-        type reader_t = reader_t_Struct_12410354185295152851
+        type struct_t = [`Struct_ac3a6f60ef4cc6d3]
+        type t = struct_t builder_t
         let type_id_get x =
           BA_.get_uint64 ~default:Uint64.zero x 8
         let type_id_get_int_exn x =
@@ -3383,16 +3184,16 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let type_id_set x v =
           BA_.set_uint64 ~default:Uint64.zero x 8 v
         let type_id_set_int_exn x v = type_id_set x (Capnp.Runtime.Util.uint64_of_int_exn v)
-        let has_brand x = 
-          (BA_.has_field x 0)
-        let brand_get x = 
-          (BA_.get_struct ~data_words:0 ~pointer_words:1 x 0)
-        let brand_set_reader x v = 
-          (BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 (v))
-        let brand_set_builder x v = 
-          (BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 (Some (v)))
-        let brand_init x = 
-          (BA_.init_struct ~data_words:0 ~pointer_words:1 x 0)
+        let has_brand x =
+          BA_.has_field x 0
+        let brand_get x =
+          BA_.get_struct ~data_words:0 ~pointer_words:1 x 0
+        let brand_set_reader x v =
+          BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 v
+        let brand_set_builder x v =
+          BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 (Some v)
+        let brand_init x =
+          BA_.init_struct ~data_words:0 ~pointer_words:1 x 0
         let of_message x = BA_.get_root_struct ~data_words:3 ~pointer_words:1 x
         let to_message x = x.BA_.NM.StructStorage.data.MessageWrapper.Slice.msg
         let to_reader x = Some (RA_.StructStorage.readonly x)
@@ -3402,8 +3203,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           BA_.init_struct_pointer ptr ~data_words:3 ~pointer_words:1
       end
       module Interface = struct
-        type t = builder_t_Interface_17116997365232503999
-        type reader_t = reader_t_Interface_17116997365232503999
+        type struct_t = [`Interface_ed8bca69f7fb0cbf]
+        type t = struct_t builder_t
         let type_id_get x =
           BA_.get_uint64 ~default:Uint64.zero x 8
         let type_id_get_int_exn x =
@@ -3411,16 +3212,16 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let type_id_set x v =
           BA_.set_uint64 ~default:Uint64.zero x 8 v
         let type_id_set_int_exn x v = type_id_set x (Capnp.Runtime.Util.uint64_of_int_exn v)
-        let has_brand x = 
-          (BA_.has_field x 0)
-        let brand_get x = 
-          (BA_.get_struct ~data_words:0 ~pointer_words:1 x 0)
-        let brand_set_reader x v = 
-          (BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 (v))
-        let brand_set_builder x v = 
-          (BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 (Some (v)))
-        let brand_init x = 
-          (BA_.init_struct ~data_words:0 ~pointer_words:1 x 0)
+        let has_brand x =
+          BA_.has_field x 0
+        let brand_get x =
+          BA_.get_struct ~data_words:0 ~pointer_words:1 x 0
+        let brand_set_reader x v =
+          BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 v
+        let brand_set_builder x v =
+          BA_.set_struct ~data_words:0 ~pointer_words:1 x 0 (Some v)
+        let brand_init x =
+          BA_.init_struct ~data_words:0 ~pointer_words:1 x 0
         let of_message x = BA_.get_root_struct ~data_words:3 ~pointer_words:1 x
         let to_message x = x.BA_.NM.StructStorage.data.MessageWrapper.Slice.msg
         let to_reader x = Some (RA_.StructStorage.readonly x)
@@ -3430,11 +3231,11 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           BA_.init_struct_pointer ptr ~data_words:3 ~pointer_words:1
       end
       module AnyPointer = struct
-        type t = builder_t_AnyPointer_14003731834718800369
-        type reader_t = reader_t_AnyPointer_14003731834718800369
+        type struct_t = [`AnyPointer_c2573fe8a23e49f1]
+        type t = struct_t builder_t
         module Unconstrained = struct
-          type t = builder_t_Unconstrained_10248890354574636630
-          type reader_t = reader_t_Unconstrained_10248890354574636630
+          type struct_t = [`Unconstrained_8e3b5f79fe593656]
+          type t = struct_t builder_t
           let any_kind_get x = ()
           let any_kind_set x =
             BA_.set_void ~discr:{BA_.Discr.value=0; BA_.Discr.byte_ofs=10} x
@@ -3469,8 +3270,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
             BA_.init_struct_pointer ptr ~data_words:3 ~pointer_words:1
         end
         module Parameter = struct
-          type t = builder_t_Parameter_11372142272178113157
-          type reader_t = reader_t_Parameter_11372142272178113157
+          type struct_t = [`Parameter_9dd1f724f4614a85]
+          type t = struct_t builder_t
           let scope_id_get x =
             BA_.get_uint64 ~default:Uint64.zero x 16
           let scope_id_get_int_exn x =
@@ -3491,8 +3292,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
             BA_.init_struct_pointer ptr ~data_words:3 ~pointer_words:1
         end
         module ImplicitMethodParameter = struct
-          type t = builder_t_ImplicitMethodParameter_13470206089842057844
-          type reader_t = reader_t_ImplicitMethodParameter_13470206089842057844
+          type struct_t = [`ImplicitMethodParameter_baefc9120c56e274]
+          type t = struct_t builder_t
           let parameter_index_get x =
             BA_.get_uint16 ~default:0 x 10
           let parameter_index_set_exn x v =
@@ -3746,23 +3547,23 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         BA_.init_struct_pointer ptr ~data_words:3 ~pointer_words:1
     end
     module Brand = struct
-      type t = builder_t_Brand_10391024731148337707
-      type reader_t = reader_t_Brand_10391024731148337707
+      type struct_t = [`Brand_903455f06065422b]
+      type t = struct_t builder_t
       module Scope = struct
-        type t = builder_t_Scope_12382423449155627977
-        type reader_t = reader_t_Scope_12382423449155627977
-        let has_bind x = 
-          (BA_.has_field x 0)
+        type struct_t = [`Scope_abd73485a9636bc9]
+        type t = struct_t builder_t
+        let has_bind x =
+          BA_.has_field x 0
         let bind_get x = 
-          (BA_.get_struct_list ~data_words:1 ~pointer_words:1 x 0)
+          BA_.get_struct_list ~data_words:1 ~pointer_words:1 x 0
         let bind_get_list x =
           Capnp.Array.to_list (bind_get x)
         let bind_get_array x =
           Capnp.Array.to_array (bind_get x)
-        let bind_set x v = 
-          (BA_.set_struct_list ~data_words:1 ~pointer_words:1 ~discr:{BA_.Discr.value=0; BA_.Discr.byte_ofs=8} x 0 (v))
-        let bind_init x n = 
-          (BA_.init_struct_list ~data_words:1 ~pointer_words:1 ~discr:{BA_.Discr.value=0; BA_.Discr.byte_ofs=8} x 0 n)
+        let bind_set x v =
+          BA_.set_struct_list ~data_words:1 ~pointer_words:1 ~discr:{BA_.Discr.value=0; BA_.Discr.byte_ofs=8} x 0 v
+        let bind_init x n =
+          BA_.init_struct_list ~data_words:1 ~pointer_words:1 ~discr:{BA_.Discr.value=0; BA_.Discr.byte_ofs=8} x 0 n
         let bind_set_list x v =
           let builder = bind_init x (List.length v) in
           let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -3775,7 +3576,7 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let inherit_set x =
           BA_.set_void ~discr:{BA_.Discr.value=1; BA_.Discr.byte_ofs=8} x
         type unnamed_union_t =
-          | Bind of (rw, builder_t_Binding_14439610327179913212, array_t) Capnp.Array.t
+          | Bind of (rw, [`Binding_c863cd16969ee7fc] builder_t, array_t) Capnp.Array.t
           | Inherit
           | Undefined of int
         let get x =
@@ -3799,21 +3600,21 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           BA_.init_struct_pointer ptr ~data_words:2 ~pointer_words:1
       end
       module Binding = struct
-        type t = builder_t_Binding_14439610327179913212
-        type reader_t = reader_t_Binding_14439610327179913212
+        type struct_t = [`Binding_c863cd16969ee7fc]
+        type t = struct_t builder_t
         let unbound_get x = ()
         let unbound_set x =
           BA_.set_void ~discr:{BA_.Discr.value=0; BA_.Discr.byte_ofs=0} x
-        let has_type x = 
-          (BA_.has_field x 0)
-        let type_get x = 
-          (BA_.get_struct ~data_words:3 ~pointer_words:1 x 0)
-        let type_set_reader x v = 
-          (BA_.set_struct ~data_words:3 ~pointer_words:1 ~discr:{BA_.Discr.value=1; BA_.Discr.byte_ofs=0} x 0 (v))
-        let type_set_builder x v = 
-          (BA_.set_struct ~data_words:3 ~pointer_words:1 ~discr:{BA_.Discr.value=1; BA_.Discr.byte_ofs=0} x 0 (Some (v)))
-        let type_init x = 
-          (BA_.init_struct ~data_words:3 ~pointer_words:1 ~discr:{BA_.Discr.value=1; BA_.Discr.byte_ofs=0} x 0)
+        let has_type x =
+          BA_.has_field x 0
+        let type_get x =
+          BA_.get_struct ~data_words:3 ~pointer_words:1 x 0
+        let type_set_reader x v =
+          BA_.set_struct ~data_words:3 ~pointer_words:1 ~discr:{BA_.Discr.value=1; BA_.Discr.byte_ofs=0} x 0 v
+        let type_set_builder x v =
+          BA_.set_struct ~data_words:3 ~pointer_words:1 ~discr:{BA_.Discr.value=1; BA_.Discr.byte_ofs=0} x 0 (Some v)
+        let type_init x =
+          BA_.init_struct ~data_words:3 ~pointer_words:1 ~discr:{BA_.Discr.value=1; BA_.Discr.byte_ofs=0} x 0
         type unnamed_union_t =
           | Unbound
           | Type of Type.t
@@ -3831,18 +3632,18 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let init_pointer ptr =
           BA_.init_struct_pointer ptr ~data_words:1 ~pointer_words:1
       end
-      let has_scopes x = 
-        (BA_.has_field x 0)
+      let has_scopes x =
+        BA_.has_field x 0
       let scopes_get x = 
-        (BA_.get_struct_list ~data_words:2 ~pointer_words:1 x 0)
+        BA_.get_struct_list ~data_words:2 ~pointer_words:1 x 0
       let scopes_get_list x =
         Capnp.Array.to_list (scopes_get x)
       let scopes_get_array x =
         Capnp.Array.to_array (scopes_get x)
-      let scopes_set x v = 
-        (BA_.set_struct_list ~data_words:2 ~pointer_words:1 x 0 (v))
-      let scopes_init x n = 
-        (BA_.init_struct_list ~data_words:2 ~pointer_words:1 x 0 n)
+      let scopes_set x v =
+        BA_.set_struct_list ~data_words:2 ~pointer_words:1 x 0 v
+      let scopes_init x n =
+        BA_.init_struct_list ~data_words:2 ~pointer_words:1 x 0 n
       let scopes_set_list x v =
         let builder = scopes_init x (List.length v) in
         let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -3860,8 +3661,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         BA_.init_struct_pointer ptr ~data_words:0 ~pointer_words:1
     end
     module Value = struct
-      type t = builder_t_Value_14853958794117909659
-      type reader_t = reader_t_Value_14853958794117909659
+      type struct_t = [`Value_ce23dcd2d7b00c9b]
+      type t = struct_t builder_t
       let void_get x = ()
       let void_set x =
         BA_.set_void ~discr:{BA_.Discr.value=0; BA_.Discr.byte_ofs=0} x
@@ -4022,8 +3823,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         BA_.init_struct_pointer ptr ~data_words:2 ~pointer_words:1
     end
     module Annotation = struct
-      type t = builder_t_Annotation_17422339044421236034
-      type reader_t = reader_t_Annotation_17422339044421236034
+      type struct_t = [`Annotation_f1c8950dab257542]
+      type t = struct_t builder_t
       let id_get x =
         BA_.get_uint64 ~default:Uint64.zero x 0
       let id_get_int_exn x =
@@ -4031,26 +3832,26 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
       let id_set x v =
         BA_.set_uint64 ~default:Uint64.zero x 0 v
       let id_set_int_exn x v = id_set x (Capnp.Runtime.Util.uint64_of_int_exn v)
-      let has_brand x = 
-        (BA_.has_field x 1)
-      let brand_get x = 
-        (BA_.get_struct ~data_words:0 ~pointer_words:1 x 1)
-      let brand_set_reader x v = 
-        (BA_.set_struct ~data_words:0 ~pointer_words:1 x 1 (v))
-      let brand_set_builder x v = 
-        (BA_.set_struct ~data_words:0 ~pointer_words:1 x 1 (Some (v)))
-      let brand_init x = 
-        (BA_.init_struct ~data_words:0 ~pointer_words:1 x 1)
-      let has_value x = 
-        (BA_.has_field x 0)
-      let value_get x = 
-        (BA_.get_struct ~data_words:2 ~pointer_words:1 x 0)
-      let value_set_reader x v = 
-        (BA_.set_struct ~data_words:2 ~pointer_words:1 x 0 (v))
-      let value_set_builder x v = 
-        (BA_.set_struct ~data_words:2 ~pointer_words:1 x 0 (Some (v)))
-      let value_init x = 
-        (BA_.init_struct ~data_words:2 ~pointer_words:1 x 0)
+      let has_brand x =
+        BA_.has_field x 1
+      let brand_get x =
+        BA_.get_struct ~data_words:0 ~pointer_words:1 x 1
+      let brand_set_reader x v =
+        BA_.set_struct ~data_words:0 ~pointer_words:1 x 1 v
+      let brand_set_builder x v =
+        BA_.set_struct ~data_words:0 ~pointer_words:1 x 1 (Some v)
+      let brand_init x =
+        BA_.init_struct ~data_words:0 ~pointer_words:1 x 1
+      let has_value x =
+        BA_.has_field x 0
+      let value_get x =
+        BA_.get_struct ~data_words:2 ~pointer_words:1 x 0
+      let value_set_reader x v =
+        BA_.set_struct ~data_words:2 ~pointer_words:1 x 0 v
+      let value_set_builder x v =
+        BA_.set_struct ~data_words:2 ~pointer_words:1 x 0 (Some v)
+      let value_init x =
+        BA_.init_struct ~data_words:2 ~pointer_words:1 x 0
       let of_message x = BA_.get_root_struct ~data_words:1 ~pointer_words:2 x
       let to_message x = x.BA_.NM.StructStorage.data.MessageWrapper.Slice.msg
       let to_reader x = Some (RA_.StructStorage.readonly x)
@@ -4072,8 +3873,8 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         | Undefined of int
     end
     module CapnpVersion = struct
-      type t = builder_t_CapnpVersion_15590670654532458851
-      type reader_t = reader_t_CapnpVersion_15590670654532458851
+      type struct_t = [`CapnpVersion_d85d305b7d839963]
+      type t = struct_t builder_t
       let major_get x =
         BA_.get_uint16 ~default:0 x 0
       let major_set_exn x v =
@@ -4095,14 +3896,14 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         BA_.init_struct_pointer ptr ~data_words:1 ~pointer_words:0
     end
     module CodeGeneratorRequest = struct
-      type t = builder_t_CodeGeneratorRequest_13818529054586492878
-      type reader_t = reader_t_CodeGeneratorRequest_13818529054586492878
+      type struct_t = [`CodeGeneratorRequest_bfc546f6210ad7ce]
+      type t = struct_t builder_t
       module RequestedFile = struct
-        type t = builder_t_RequestedFile_14981803260258615394
-        type reader_t = reader_t_RequestedFile_14981803260258615394
+        type struct_t = [`RequestedFile_cfea0eb02e810062]
+        type t = struct_t builder_t
         module Import = struct
-          type t = builder_t_Import_12560611460656617445
-          type reader_t = reader_t_Import_12560611460656617445
+          type struct_t = [`Import_ae504193122357e5]
+          type t = struct_t builder_t
           let id_get x =
             BA_.get_uint64 ~default:Uint64.zero x 0
           let id_get_int_exn x =
@@ -4137,18 +3938,18 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
           BA_.get_text ~default:"" x 0
         let filename_set x v =
           BA_.set_text x 0 v
-        let has_imports x = 
-          (BA_.has_field x 1)
+        let has_imports x =
+          BA_.has_field x 1
         let imports_get x = 
-          (BA_.get_struct_list ~data_words:1 ~pointer_words:1 x 1)
+          BA_.get_struct_list ~data_words:1 ~pointer_words:1 x 1
         let imports_get_list x =
           Capnp.Array.to_list (imports_get x)
         let imports_get_array x =
           Capnp.Array.to_array (imports_get x)
-        let imports_set x v = 
-          (BA_.set_struct_list ~data_words:1 ~pointer_words:1 x 1 (v))
-        let imports_init x n = 
-          (BA_.init_struct_list ~data_words:1 ~pointer_words:1 x 1 n)
+        let imports_set x v =
+          BA_.set_struct_list ~data_words:1 ~pointer_words:1 x 1 v
+        let imports_init x n =
+          BA_.init_struct_list ~data_words:1 ~pointer_words:1 x 1 n
         let imports_set_list x v =
           let builder = imports_init x (List.length v) in
           let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -4165,28 +3966,28 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let init_pointer ptr =
           BA_.init_struct_pointer ptr ~data_words:1 ~pointer_words:2
       end
-      let has_capnp_version x = 
-        (BA_.has_field x 2)
-      let capnp_version_get x = 
-        (BA_.get_struct ~data_words:1 ~pointer_words:0 x 2)
-      let capnp_version_set_reader x v = 
-        (BA_.set_struct ~data_words:1 ~pointer_words:0 x 2 (v))
-      let capnp_version_set_builder x v = 
-        (BA_.set_struct ~data_words:1 ~pointer_words:0 x 2 (Some (v)))
-      let capnp_version_init x = 
-        (BA_.init_struct ~data_words:1 ~pointer_words:0 x 2)
-      let has_nodes x = 
-        (BA_.has_field x 0)
+      let has_capnp_version x =
+        BA_.has_field x 2
+      let capnp_version_get x =
+        BA_.get_struct ~data_words:1 ~pointer_words:0 x 2
+      let capnp_version_set_reader x v =
+        BA_.set_struct ~data_words:1 ~pointer_words:0 x 2 v
+      let capnp_version_set_builder x v =
+        BA_.set_struct ~data_words:1 ~pointer_words:0 x 2 (Some v)
+      let capnp_version_init x =
+        BA_.init_struct ~data_words:1 ~pointer_words:0 x 2
+      let has_nodes x =
+        BA_.has_field x 0
       let nodes_get x = 
-        (BA_.get_struct_list ~data_words:5 ~pointer_words:6 x 0)
+        BA_.get_struct_list ~data_words:5 ~pointer_words:6 x 0
       let nodes_get_list x =
         Capnp.Array.to_list (nodes_get x)
       let nodes_get_array x =
         Capnp.Array.to_array (nodes_get x)
-      let nodes_set x v = 
-        (BA_.set_struct_list ~data_words:5 ~pointer_words:6 x 0 (v))
-      let nodes_init x n = 
-        (BA_.init_struct_list ~data_words:5 ~pointer_words:6 x 0 n)
+      let nodes_set x v =
+        BA_.set_struct_list ~data_words:5 ~pointer_words:6 x 0 v
+      let nodes_init x n =
+        BA_.init_struct_list ~data_words:5 ~pointer_words:6 x 0 n
       let nodes_set_list x v =
         let builder = nodes_init x (List.length v) in
         let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in
@@ -4195,18 +3996,18 @@ module Make (MessageWrapper : Capnp.MessageSig.S) = struct
         let builder = nodes_init x (Array.length v) in
         let () = Array.iteri (fun i a -> Capnp.Array.set builder i a) v in
         builder
-      let has_requested_files x = 
-        (BA_.has_field x 1)
+      let has_requested_files x =
+        BA_.has_field x 1
       let requested_files_get x = 
-        (BA_.get_struct_list ~data_words:1 ~pointer_words:2 x 1)
+        BA_.get_struct_list ~data_words:1 ~pointer_words:2 x 1
       let requested_files_get_list x =
         Capnp.Array.to_list (requested_files_get x)
       let requested_files_get_array x =
         Capnp.Array.to_array (requested_files_get x)
-      let requested_files_set x v = 
-        (BA_.set_struct_list ~data_words:1 ~pointer_words:2 x 1 (v))
-      let requested_files_init x n = 
-        (BA_.init_struct_list ~data_words:1 ~pointer_words:2 x 1 n)
+      let requested_files_set x v =
+        BA_.set_struct_list ~data_words:1 ~pointer_words:2 x 1 v
+      let requested_files_init x n =
+        BA_.init_struct_list ~data_words:1 ~pointer_words:2 x 1 n
       let requested_files_set_list x v =
         let builder = requested_files_init x (List.length v) in
         let () = List.iteri (fun i a -> Capnp.Array.set builder i a) v in

--- a/src/compiler/pluginSchema.mli
+++ b/src/compiler/pluginSchema.mli
@@ -8,105 +8,6 @@ module type S = sig
   type 'a reader_t
   type 'a builder_t
 
-  type struct_Import_12560611460656617445
-  type reader_t_Import_12560611460656617445 = struct_Import_12560611460656617445 reader_t
-  type builder_t_Import_12560611460656617445 = struct_Import_12560611460656617445 builder_t
-  type struct_RequestedFile_14981803260258615394
-  type reader_t_RequestedFile_14981803260258615394 = struct_RequestedFile_14981803260258615394 reader_t
-  type builder_t_RequestedFile_14981803260258615394 = struct_RequestedFile_14981803260258615394 builder_t
-  type struct_CodeGeneratorRequest_13818529054586492878
-  type reader_t_CodeGeneratorRequest_13818529054586492878 = struct_CodeGeneratorRequest_13818529054586492878 reader_t
-  type builder_t_CodeGeneratorRequest_13818529054586492878 = struct_CodeGeneratorRequest_13818529054586492878 builder_t
-  type struct_CapnpVersion_15590670654532458851
-  type reader_t_CapnpVersion_15590670654532458851 = struct_CapnpVersion_15590670654532458851 reader_t
-  type builder_t_CapnpVersion_15590670654532458851 = struct_CapnpVersion_15590670654532458851 builder_t
-  type struct_Annotation_17422339044421236034
-  type reader_t_Annotation_17422339044421236034 = struct_Annotation_17422339044421236034 reader_t
-  type builder_t_Annotation_17422339044421236034 = struct_Annotation_17422339044421236034 builder_t
-  type struct_Value_14853958794117909659
-  type reader_t_Value_14853958794117909659 = struct_Value_14853958794117909659 reader_t
-  type builder_t_Value_14853958794117909659 = struct_Value_14853958794117909659 builder_t
-  type struct_Binding_14439610327179913212
-  type reader_t_Binding_14439610327179913212 = struct_Binding_14439610327179913212 reader_t
-  type builder_t_Binding_14439610327179913212 = struct_Binding_14439610327179913212 builder_t
-  type struct_Scope_12382423449155627977
-  type reader_t_Scope_12382423449155627977 = struct_Scope_12382423449155627977 reader_t
-  type builder_t_Scope_12382423449155627977 = struct_Scope_12382423449155627977 builder_t
-  type struct_Brand_10391024731148337707
-  type reader_t_Brand_10391024731148337707 = struct_Brand_10391024731148337707 reader_t
-  type builder_t_Brand_10391024731148337707 = struct_Brand_10391024731148337707 builder_t
-  type struct_ImplicitMethodParameter_13470206089842057844
-  type reader_t_ImplicitMethodParameter_13470206089842057844 = struct_ImplicitMethodParameter_13470206089842057844 reader_t
-  type builder_t_ImplicitMethodParameter_13470206089842057844 = struct_ImplicitMethodParameter_13470206089842057844 builder_t
-  type struct_Parameter_11372142272178113157
-  type reader_t_Parameter_11372142272178113157 = struct_Parameter_11372142272178113157 reader_t
-  type builder_t_Parameter_11372142272178113157 = struct_Parameter_11372142272178113157 builder_t
-  type struct_Unconstrained_10248890354574636630
-  type reader_t_Unconstrained_10248890354574636630 = struct_Unconstrained_10248890354574636630 reader_t
-  type builder_t_Unconstrained_10248890354574636630 = struct_Unconstrained_10248890354574636630 builder_t
-  type struct_AnyPointer_14003731834718800369
-  type reader_t_AnyPointer_14003731834718800369 = struct_AnyPointer_14003731834718800369 reader_t
-  type builder_t_AnyPointer_14003731834718800369 = struct_AnyPointer_14003731834718800369 builder_t
-  type struct_Interface_17116997365232503999
-  type reader_t_Interface_17116997365232503999 = struct_Interface_17116997365232503999 reader_t
-  type builder_t_Interface_17116997365232503999 = struct_Interface_17116997365232503999 builder_t
-  type struct_Struct_12410354185295152851
-  type reader_t_Struct_12410354185295152851 = struct_Struct_12410354185295152851 reader_t
-  type builder_t_Struct_12410354185295152851 = struct_Struct_12410354185295152851 builder_t
-  type struct_Enum_11389172934837766057
-  type reader_t_Enum_11389172934837766057 = struct_Enum_11389172934837766057 reader_t
-  type builder_t_Enum_11389172934837766057 = struct_Enum_11389172934837766057 builder_t
-  type struct_List_9792858745991129751
-  type reader_t_List_9792858745991129751 = struct_List_9792858745991129751 reader_t
-  type builder_t_List_9792858745991129751 = struct_List_9792858745991129751 builder_t
-  type struct_Type_15020482145304562784
-  type reader_t_Type_15020482145304562784 = struct_Type_15020482145304562784 reader_t
-  type builder_t_Type_15020482145304562784 = struct_Type_15020482145304562784 builder_t
-  type struct_Method_10736806783679155584
-  type reader_t_Method_10736806783679155584 = struct_Method_10736806783679155584 reader_t
-  type builder_t_Method_10736806783679155584 = struct_Method_10736806783679155584 builder_t
-  type struct_Superclass_12220001500510083064
-  type reader_t_Superclass_12220001500510083064 = struct_Superclass_12220001500510083064 reader_t
-  type builder_t_Superclass_12220001500510083064 = struct_Superclass_12220001500510083064 builder_t
-  type struct_Enumerant_10919677598968879693
-  type reader_t_Enumerant_10919677598968879693 = struct_Enumerant_10919677598968879693 reader_t
-  type builder_t_Enumerant_10919677598968879693 = struct_Enumerant_10919677598968879693 builder_t
-  type struct_Ordinal_13515537513213004774
-  type reader_t_Ordinal_13515537513213004774 = struct_Ordinal_13515537513213004774 reader_t
-  type builder_t_Ordinal_13515537513213004774 = struct_Ordinal_13515537513213004774 builder_t
-  type struct_Group_14626792032033250577
-  type reader_t_Group_14626792032033250577 = struct_Group_14626792032033250577 reader_t
-  type builder_t_Group_14626792032033250577 = struct_Group_14626792032033250577 builder_t
-  type struct_Slot_14133145859926553711
-  type reader_t_Slot_14133145859926553711 = struct_Slot_14133145859926553711 reader_t
-  type builder_t_Slot_14133145859926553711 = struct_Slot_14133145859926553711 builder_t
-  type struct_Field_11145653318641710175
-  type reader_t_Field_11145653318641710175 = struct_Field_11145653318641710175 reader_t
-  type builder_t_Field_11145653318641710175 = struct_Field_11145653318641710175 builder_t
-  type struct_NestedNode_16050641862814319170
-  type reader_t_NestedNode_16050641862814319170 = struct_NestedNode_16050641862814319170 reader_t
-  type builder_t_NestedNode_16050641862814319170 = struct_NestedNode_16050641862814319170 builder_t
-  type struct_Parameter_13353766412138554289
-  type reader_t_Parameter_13353766412138554289 = struct_Parameter_13353766412138554289 reader_t
-  type builder_t_Parameter_13353766412138554289 = struct_Parameter_13353766412138554289 builder_t
-  type struct_Annotation_17011813041836786320
-  type reader_t_Annotation_17011813041836786320 = struct_Annotation_17011813041836786320 reader_t
-  type builder_t_Annotation_17011813041836786320 = struct_Annotation_17011813041836786320 builder_t
-  type struct_Const_12793219851699983392
-  type reader_t_Const_12793219851699983392 = struct_Const_12793219851699983392 reader_t
-  type builder_t_Const_12793219851699983392 = struct_Const_12793219851699983392 builder_t
-  type struct_Interface_16728431493453586831
-  type reader_t_Interface_16728431493453586831 = struct_Interface_16728431493453586831 reader_t
-  type builder_t_Interface_16728431493453586831 = struct_Interface_16728431493453586831 builder_t
-  type struct_Enum_13063450714778629528
-  type reader_t_Enum_13063450714778629528 = struct_Enum_13063450714778629528 reader_t
-  type builder_t_Enum_13063450714778629528 = struct_Enum_13063450714778629528 builder_t
-  type struct_Struct_11430331134483579957
-  type reader_t_Struct_11430331134483579957 = struct_Struct_11430331134483579957 reader_t
-  type builder_t_Struct_11430331134483579957 = struct_Struct_11430331134483579957 builder_t
-  type struct_Node_16610026722781537303
-  type reader_t_Node_16610026722781537303 = struct_Node_16610026722781537303 reader_t
-  type builder_t_Node_16610026722781537303 = struct_Node_16610026722781537303 builder_t
   module ElementSize_15102134695616452902 : sig
     type t =
       | Empty
@@ -126,11 +27,11 @@ module type S = sig
     type pointer_t
     val of_pointer : pointer_t -> 'a reader_t
     module Node : sig
-      type t = reader_t_Node_16610026722781537303
-      type builder_t = builder_t_Node_16610026722781537303
+      type struct_t = [`Node_e682ab4cf923a417]
+      type t = struct_t reader_t
       module Struct : sig
-        type t = reader_t_Struct_11430331134483579957
-        type builder_t = builder_t_Struct_11430331134483579957
+        type struct_t = [`Struct_9ea0b19b37fb4435]
+        type t = struct_t reader_t
         val data_word_count_get : t -> int
         val pointer_count_get : t -> int
         val preferred_list_encoding_get : t -> ElementSize_15102134695616452902.t
@@ -139,51 +40,51 @@ module type S = sig
         val discriminant_offset_get : t -> Uint32.t
         val discriminant_offset_get_int_exn : t -> int
         val has_fields : t -> bool
-        val fields_get : t -> (ro, reader_t_Field_11145653318641710175, array_t) Capnp.Array.t
-        val fields_get_list : t -> reader_t_Field_11145653318641710175 list
-        val fields_get_array : t -> reader_t_Field_11145653318641710175 array
+        val fields_get : t -> (ro, [`Field_9aad50a41f4af45f] reader_t, array_t) Capnp.Array.t
+        val fields_get_list : t -> [`Field_9aad50a41f4af45f] reader_t list
+        val fields_get_array : t -> [`Field_9aad50a41f4af45f] reader_t array
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Enum : sig
-        type t = reader_t_Enum_13063450714778629528
-        type builder_t = builder_t_Enum_13063450714778629528
+        type struct_t = [`Enum_b54ab3364333f598]
+        type t = struct_t reader_t
         val has_enumerants : t -> bool
-        val enumerants_get : t -> (ro, reader_t_Enumerant_10919677598968879693, array_t) Capnp.Array.t
-        val enumerants_get_list : t -> reader_t_Enumerant_10919677598968879693 list
-        val enumerants_get_array : t -> reader_t_Enumerant_10919677598968879693 array
+        val enumerants_get : t -> (ro, [`Enumerant_978a7cebdc549a4d] reader_t, array_t) Capnp.Array.t
+        val enumerants_get_list : t -> [`Enumerant_978a7cebdc549a4d] reader_t list
+        val enumerants_get_array : t -> [`Enumerant_978a7cebdc549a4d] reader_t array
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Interface : sig
-        type t = reader_t_Interface_16728431493453586831
-        type builder_t = builder_t_Interface_16728431493453586831
+        type struct_t = [`Interface_e82753cff0c2218f]
+        type t = struct_t reader_t
         val has_methods : t -> bool
-        val methods_get : t -> (ro, reader_t_Method_10736806783679155584, array_t) Capnp.Array.t
-        val methods_get_list : t -> reader_t_Method_10736806783679155584 list
-        val methods_get_array : t -> reader_t_Method_10736806783679155584 array
+        val methods_get : t -> (ro, [`Method_9500cce23b334d80] reader_t, array_t) Capnp.Array.t
+        val methods_get_list : t -> [`Method_9500cce23b334d80] reader_t list
+        val methods_get_array : t -> [`Method_9500cce23b334d80] reader_t array
         val has_superclasses : t -> bool
-        val superclasses_get : t -> (ro, reader_t_Superclass_12220001500510083064, array_t) Capnp.Array.t
-        val superclasses_get_list : t -> reader_t_Superclass_12220001500510083064 list
-        val superclasses_get_array : t -> reader_t_Superclass_12220001500510083064 array
+        val superclasses_get : t -> (ro, [`Superclass_a9962a9ed0a4d7f8] reader_t, array_t) Capnp.Array.t
+        val superclasses_get_list : t -> [`Superclass_a9962a9ed0a4d7f8] reader_t list
+        val superclasses_get_array : t -> [`Superclass_a9962a9ed0a4d7f8] reader_t array
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Const : sig
-        type t = reader_t_Const_12793219851699983392
-        type builder_t = builder_t_Const_12793219851699983392
+        type struct_t = [`Const_b18aa5ac7a0d9420]
+        type t = struct_t reader_t
         val has_type : t -> bool
-        val type_get : t -> reader_t_Type_15020482145304562784
+        val type_get : t -> [`Type_d07378ede1f9cc60] reader_t
         val has_value : t -> bool
-        val value_get : t -> reader_t_Value_14853958794117909659
+        val value_get : t -> [`Value_ce23dcd2d7b00c9b] reader_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Annotation : sig
-        type t = reader_t_Annotation_17011813041836786320
-        type builder_t = builder_t_Annotation_17011813041836786320
+        type struct_t = [`Annotation_ec1619d4400a0290]
+        type t = struct_t reader_t
         val has_type : t -> bool
-        val type_get : t -> reader_t_Type_15020482145304562784
+        val type_get : t -> [`Type_d07378ede1f9cc60] reader_t
         val targets_file_get : t -> bool
         val targets_const_get : t -> bool
         val targets_enum_get : t -> bool
@@ -197,25 +98,25 @@ module type S = sig
         val targets_param_get : t -> bool
         val targets_annotation_get : t -> bool
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Parameter : sig
-        type t = reader_t_Parameter_13353766412138554289
-        type builder_t = builder_t_Parameter_13353766412138554289
+        type struct_t = [`Parameter_b9521bccf10fa3b1]
+        type t = struct_t reader_t
         val has_name : t -> bool
         val name_get : t -> string
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module NestedNode : sig
-        type t = reader_t_NestedNode_16050641862814319170
-        type builder_t = builder_t_NestedNode_16050641862814319170
+        type struct_t = [`NestedNode_debf55bbfa0fc242]
+        type t = struct_t reader_t
         val has_name : t -> bool
         val name_get : t -> string
         val id_get : t -> Uint64.t
         val id_get_int_exn : t -> int
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       type unnamed_union_t =
         | File
@@ -235,55 +136,55 @@ module type S = sig
       val scope_id_get : t -> Uint64.t
       val scope_id_get_int_exn : t -> int
       val has_parameters : t -> bool
-      val parameters_get : t -> (ro, reader_t_Parameter_13353766412138554289, array_t) Capnp.Array.t
-      val parameters_get_list : t -> reader_t_Parameter_13353766412138554289 list
-      val parameters_get_array : t -> reader_t_Parameter_13353766412138554289 array
+      val parameters_get : t -> (ro, [`Parameter_b9521bccf10fa3b1] reader_t, array_t) Capnp.Array.t
+      val parameters_get_list : t -> [`Parameter_b9521bccf10fa3b1] reader_t list
+      val parameters_get_array : t -> [`Parameter_b9521bccf10fa3b1] reader_t array
       val is_generic_get : t -> bool
       val has_nested_nodes : t -> bool
-      val nested_nodes_get : t -> (ro, reader_t_NestedNode_16050641862814319170, array_t) Capnp.Array.t
-      val nested_nodes_get_list : t -> reader_t_NestedNode_16050641862814319170 list
-      val nested_nodes_get_array : t -> reader_t_NestedNode_16050641862814319170 array
+      val nested_nodes_get : t -> (ro, [`NestedNode_debf55bbfa0fc242] reader_t, array_t) Capnp.Array.t
+      val nested_nodes_get_list : t -> [`NestedNode_debf55bbfa0fc242] reader_t list
+      val nested_nodes_get_array : t -> [`NestedNode_debf55bbfa0fc242] reader_t array
       val has_annotations : t -> bool
-      val annotations_get : t -> (ro, reader_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> reader_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> reader_t_Annotation_17422339044421236034 array
+      val annotations_get : t -> (ro, [`Annotation_f1c8950dab257542] reader_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] reader_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] reader_t array
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Field : sig
-      type t = reader_t_Field_11145653318641710175
-      type builder_t = builder_t_Field_11145653318641710175
+      type struct_t = [`Field_9aad50a41f4af45f]
+      type t = struct_t reader_t
       module Slot : sig
-        type t = reader_t_Slot_14133145859926553711
-        type builder_t = builder_t_Slot_14133145859926553711
+        type struct_t = [`Slot_c42305476bb4746f]
+        type t = struct_t reader_t
         val offset_get : t -> Uint32.t
         val offset_get_int_exn : t -> int
         val has_type : t -> bool
-        val type_get : t -> reader_t_Type_15020482145304562784
+        val type_get : t -> [`Type_d07378ede1f9cc60] reader_t
         val has_default_value : t -> bool
-        val default_value_get : t -> reader_t_Value_14853958794117909659
+        val default_value_get : t -> [`Value_ce23dcd2d7b00c9b] reader_t
         val had_explicit_default_get : t -> bool
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Group : sig
-        type t = reader_t_Group_14626792032033250577
-        type builder_t = builder_t_Group_14626792032033250577
+        type struct_t = [`Group_cafccddb68db1d11]
+        type t = struct_t reader_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Ordinal : sig
-        type t = reader_t_Ordinal_13515537513213004774
-        type builder_t = builder_t_Ordinal_13515537513213004774
+        type struct_t = [`Ordinal_bb90d5c287870be6]
+        type t = struct_t reader_t
         type unnamed_union_t =
           | Implicit
           | Explicit of int
           | Undefined of int
         val get : t -> unnamed_union_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       val no_discriminant : int
       type unnamed_union_t =
@@ -295,40 +196,40 @@ module type S = sig
       val name_get : t -> string
       val code_order_get : t -> int
       val has_annotations : t -> bool
-      val annotations_get : t -> (ro, reader_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> reader_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> reader_t_Annotation_17422339044421236034 array
+      val annotations_get : t -> (ro, [`Annotation_f1c8950dab257542] reader_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] reader_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] reader_t array
       val discriminant_value_get : t -> int
       val ordinal_get : t -> Ordinal.t
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Enumerant : sig
-      type t = reader_t_Enumerant_10919677598968879693
-      type builder_t = builder_t_Enumerant_10919677598968879693
+      type struct_t = [`Enumerant_978a7cebdc549a4d]
+      type t = struct_t reader_t
       val has_name : t -> bool
       val name_get : t -> string
       val code_order_get : t -> int
       val has_annotations : t -> bool
-      val annotations_get : t -> (ro, reader_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> reader_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> reader_t_Annotation_17422339044421236034 array
+      val annotations_get : t -> (ro, [`Annotation_f1c8950dab257542] reader_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] reader_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] reader_t array
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Superclass : sig
-      type t = reader_t_Superclass_12220001500510083064
-      type builder_t = builder_t_Superclass_12220001500510083064
+      type struct_t = [`Superclass_a9962a9ed0a4d7f8]
+      type t = struct_t reader_t
       val id_get : t -> Uint64.t
       val id_get_int_exn : t -> int
       val has_brand : t -> bool
-      val brand_get : t -> reader_t_Brand_10391024731148337707
+      val brand_get : t -> [`Brand_903455f06065422b] reader_t
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Method : sig
-      type t = reader_t_Method_10736806783679155584
-      type builder_t = builder_t_Method_10736806783679155584
+      type struct_t = [`Method_9500cce23b334d80]
+      type t = struct_t reader_t
       val has_name : t -> bool
       val name_get : t -> string
       val code_order_get : t -> int
@@ -339,65 +240,65 @@ module type S = sig
       val param_struct_type_get : t -> Uint64.t
       val param_struct_type_get_int_exn : t -> int
       val has_param_brand : t -> bool
-      val param_brand_get : t -> reader_t_Brand_10391024731148337707
+      val param_brand_get : t -> [`Brand_903455f06065422b] reader_t
       val result_struct_type_get : t -> Uint64.t
       val result_struct_type_get_int_exn : t -> int
       val has_result_brand : t -> bool
-      val result_brand_get : t -> reader_t_Brand_10391024731148337707
+      val result_brand_get : t -> [`Brand_903455f06065422b] reader_t
       val has_annotations : t -> bool
-      val annotations_get : t -> (ro, reader_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> reader_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> reader_t_Annotation_17422339044421236034 array
+      val annotations_get : t -> (ro, [`Annotation_f1c8950dab257542] reader_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] reader_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] reader_t array
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Type : sig
-      type t = reader_t_Type_15020482145304562784
-      type builder_t = builder_t_Type_15020482145304562784
+      type struct_t = [`Type_d07378ede1f9cc60]
+      type t = struct_t reader_t
       module List : sig
-        type t = reader_t_List_9792858745991129751
-        type builder_t = builder_t_List_9792858745991129751
+        type struct_t = [`List_87e739250a60ea97]
+        type t = struct_t reader_t
         val has_element_type : t -> bool
-        val element_type_get : t -> reader_t_Type_15020482145304562784
+        val element_type_get : t -> [`Type_d07378ede1f9cc60] reader_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Enum : sig
-        type t = reader_t_Enum_11389172934837766057
-        type builder_t = builder_t_Enum_11389172934837766057
+        type struct_t = [`Enum_9e0e78711a7f87a9]
+        type t = struct_t reader_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val has_brand : t -> bool
-        val brand_get : t -> reader_t_Brand_10391024731148337707
+        val brand_get : t -> [`Brand_903455f06065422b] reader_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Struct : sig
-        type t = reader_t_Struct_12410354185295152851
-        type builder_t = builder_t_Struct_12410354185295152851
+        type struct_t = [`Struct_ac3a6f60ef4cc6d3]
+        type t = struct_t reader_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val has_brand : t -> bool
-        val brand_get : t -> reader_t_Brand_10391024731148337707
+        val brand_get : t -> [`Brand_903455f06065422b] reader_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Interface : sig
-        type t = reader_t_Interface_17116997365232503999
-        type builder_t = builder_t_Interface_17116997365232503999
+        type struct_t = [`Interface_ed8bca69f7fb0cbf]
+        type t = struct_t reader_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val has_brand : t -> bool
-        val brand_get : t -> reader_t_Brand_10391024731148337707
+        val brand_get : t -> [`Brand_903455f06065422b] reader_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module AnyPointer : sig
-        type t = reader_t_AnyPointer_14003731834718800369
-        type builder_t = builder_t_AnyPointer_14003731834718800369
+        type struct_t = [`AnyPointer_c2573fe8a23e49f1]
+        type t = struct_t reader_t
         module Unconstrained : sig
-          type t = reader_t_Unconstrained_10248890354574636630
-          type builder_t = builder_t_Unconstrained_10248890354574636630
+          type struct_t = [`Unconstrained_8e3b5f79fe593656]
+          type t = struct_t reader_t
           type unnamed_union_t =
             | AnyKind
             | Struct
@@ -406,23 +307,23 @@ module type S = sig
             | Undefined of int
           val get : t -> unnamed_union_t
           val of_message : 'cap message_t -> t
-          val of_builder : builder_t -> t
+          val of_builder : struct_t builder_t -> t
         end
         module Parameter : sig
-          type t = reader_t_Parameter_11372142272178113157
-          type builder_t = builder_t_Parameter_11372142272178113157
+          type struct_t = [`Parameter_9dd1f724f4614a85]
+          type t = struct_t reader_t
           val scope_id_get : t -> Uint64.t
           val scope_id_get_int_exn : t -> int
           val parameter_index_get : t -> int
           val of_message : 'cap message_t -> t
-          val of_builder : builder_t -> t
+          val of_builder : struct_t builder_t -> t
         end
         module ImplicitMethodParameter : sig
-          type t = reader_t_ImplicitMethodParameter_13470206089842057844
-          type builder_t = builder_t_ImplicitMethodParameter_13470206089842057844
+          type struct_t = [`ImplicitMethodParameter_baefc9120c56e274]
+          type t = struct_t reader_t
           val parameter_index_get : t -> int
           val of_message : 'cap message_t -> t
-          val of_builder : builder_t -> t
+          val of_builder : struct_t builder_t -> t
         end
         type unnamed_union_t =
           | Unconstrained of Unconstrained.t
@@ -431,7 +332,7 @@ module type S = sig
           | Undefined of int
         val get : t -> unnamed_union_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       type unnamed_union_t =
         | Void
@@ -456,45 +357,45 @@ module type S = sig
         | Undefined of int
       val get : t -> unnamed_union_t
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Brand : sig
-      type t = reader_t_Brand_10391024731148337707
-      type builder_t = builder_t_Brand_10391024731148337707
+      type struct_t = [`Brand_903455f06065422b]
+      type t = struct_t reader_t
       module Scope : sig
-        type t = reader_t_Scope_12382423449155627977
-        type builder_t = builder_t_Scope_12382423449155627977
+        type struct_t = [`Scope_abd73485a9636bc9]
+        type t = struct_t reader_t
         type unnamed_union_t =
-          | Bind of (ro, reader_t_Binding_14439610327179913212, array_t) Capnp.Array.t
+          | Bind of (ro, [`Binding_c863cd16969ee7fc] reader_t, array_t) Capnp.Array.t
           | Inherit
           | Undefined of int
         val get : t -> unnamed_union_t
         val scope_id_get : t -> Uint64.t
         val scope_id_get_int_exn : t -> int
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       module Binding : sig
-        type t = reader_t_Binding_14439610327179913212
-        type builder_t = builder_t_Binding_14439610327179913212
+        type struct_t = [`Binding_c863cd16969ee7fc]
+        type t = struct_t reader_t
         type unnamed_union_t =
           | Unbound
           | Type of Type.t
           | Undefined of int
         val get : t -> unnamed_union_t
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       val has_scopes : t -> bool
-      val scopes_get : t -> (ro, reader_t_Scope_12382423449155627977, array_t) Capnp.Array.t
-      val scopes_get_list : t -> reader_t_Scope_12382423449155627977 list
-      val scopes_get_array : t -> reader_t_Scope_12382423449155627977 array
+      val scopes_get : t -> (ro, [`Scope_abd73485a9636bc9] reader_t, array_t) Capnp.Array.t
+      val scopes_get_list : t -> [`Scope_abd73485a9636bc9] reader_t list
+      val scopes_get_array : t -> [`Scope_abd73485a9636bc9] reader_t array
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Value : sig
-      type t = reader_t_Value_14853958794117909659
-      type builder_t = builder_t_Value_14853958794117909659
+      type struct_t = [`Value_ce23dcd2d7b00c9b]
+      type t = struct_t reader_t
       type unnamed_union_t =
         | Void
         | Bool of bool
@@ -518,11 +419,11 @@ module type S = sig
         | Undefined of int
       val get : t -> unnamed_union_t
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module Annotation : sig
-      type t = reader_t_Annotation_17422339044421236034
-      type builder_t = builder_t_Annotation_17422339044421236034
+      type struct_t = [`Annotation_f1c8950dab257542]
+      type t = struct_t reader_t
       val id_get : t -> Uint64.t
       val id_get_int_exn : t -> int
       val has_brand : t -> bool
@@ -530,7 +431,7 @@ module type S = sig
       val has_value : t -> bool
       val value_get : t -> Value.t
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module ElementSize : sig
       type t = ElementSize_15102134695616452902.t =
@@ -545,40 +446,40 @@ module type S = sig
         | Undefined of int
     end
     module CapnpVersion : sig
-      type t = reader_t_CapnpVersion_15590670654532458851
-      type builder_t = builder_t_CapnpVersion_15590670654532458851
+      type struct_t = [`CapnpVersion_d85d305b7d839963]
+      type t = struct_t reader_t
       val major_get : t -> int
       val minor_get : t -> int
       val micro_get : t -> int
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
     module CodeGeneratorRequest : sig
-      type t = reader_t_CodeGeneratorRequest_13818529054586492878
-      type builder_t = builder_t_CodeGeneratorRequest_13818529054586492878
+      type struct_t = [`CodeGeneratorRequest_bfc546f6210ad7ce]
+      type t = struct_t reader_t
       module RequestedFile : sig
-        type t = reader_t_RequestedFile_14981803260258615394
-        type builder_t = builder_t_RequestedFile_14981803260258615394
+        type struct_t = [`RequestedFile_cfea0eb02e810062]
+        type t = struct_t reader_t
         module Import : sig
-          type t = reader_t_Import_12560611460656617445
-          type builder_t = builder_t_Import_12560611460656617445
+          type struct_t = [`Import_ae504193122357e5]
+          type t = struct_t reader_t
           val id_get : t -> Uint64.t
           val id_get_int_exn : t -> int
           val has_name : t -> bool
           val name_get : t -> string
           val of_message : 'cap message_t -> t
-          val of_builder : builder_t -> t
+          val of_builder : struct_t builder_t -> t
         end
         val id_get : t -> Uint64.t
         val id_get_int_exn : t -> int
         val has_filename : t -> bool
         val filename_get : t -> string
         val has_imports : t -> bool
-        val imports_get : t -> (ro, reader_t_Import_12560611460656617445, array_t) Capnp.Array.t
-        val imports_get_list : t -> reader_t_Import_12560611460656617445 list
-        val imports_get_array : t -> reader_t_Import_12560611460656617445 array
+        val imports_get : t -> (ro, [`Import_ae504193122357e5] reader_t, array_t) Capnp.Array.t
+        val imports_get_list : t -> [`Import_ae504193122357e5] reader_t list
+        val imports_get_array : t -> [`Import_ae504193122357e5] reader_t array
         val of_message : 'cap message_t -> t
-        val of_builder : builder_t -> t
+        val of_builder : struct_t builder_t -> t
       end
       val has_capnp_version : t -> bool
       val capnp_version_get : t -> CapnpVersion.t
@@ -587,11 +488,11 @@ module type S = sig
       val nodes_get_list : t -> Node.t list
       val nodes_get_array : t -> Node.t array
       val has_requested_files : t -> bool
-      val requested_files_get : t -> (ro, reader_t_RequestedFile_14981803260258615394, array_t) Capnp.Array.t
-      val requested_files_get_list : t -> reader_t_RequestedFile_14981803260258615394 list
-      val requested_files_get_array : t -> reader_t_RequestedFile_14981803260258615394 array
+      val requested_files_get : t -> (ro, [`RequestedFile_cfea0eb02e810062] reader_t, array_t) Capnp.Array.t
+      val requested_files_get_list : t -> [`RequestedFile_cfea0eb02e810062] reader_t list
+      val requested_files_get_array : t -> [`RequestedFile_cfea0eb02e810062] reader_t array
       val of_message : 'cap message_t -> t
-      val of_builder : builder_t -> t
+      val of_builder : struct_t builder_t -> t
     end
   end
 
@@ -600,11 +501,11 @@ module type S = sig
     type reader_array_t = Reader.array_t
     type pointer_t
     module Node : sig
-      type t = builder_t_Node_16610026722781537303
-      type reader_t = reader_t_Node_16610026722781537303
+      type struct_t = [`Node_e682ab4cf923a417]
+      type t = struct_t builder_t
       module Struct : sig
-        type t = builder_t_Struct_11430331134483579957
-        type reader_t = reader_t_Struct_11430331134483579957
+        type struct_t = [`Struct_9ea0b19b37fb4435]
+        type t = struct_t builder_t
         val data_word_count_get : t -> int
         val data_word_count_set_exn : t -> int -> unit
         val pointer_count_get : t -> int
@@ -621,88 +522,88 @@ module type S = sig
         val discriminant_offset_set : t -> Uint32.t -> unit
         val discriminant_offset_set_int_exn : t -> int -> unit
         val has_fields : t -> bool
-        val fields_get : t -> (rw, builder_t_Field_11145653318641710175, array_t) Capnp.Array.t
-        val fields_get_list : t -> builder_t_Field_11145653318641710175 list
-        val fields_get_array : t -> builder_t_Field_11145653318641710175 array
-        val fields_set : t -> (rw, builder_t_Field_11145653318641710175, array_t) Capnp.Array.t -> (rw, builder_t_Field_11145653318641710175, array_t) Capnp.Array.t
-        val fields_set_list : t -> builder_t_Field_11145653318641710175 list -> (rw, builder_t_Field_11145653318641710175, array_t) Capnp.Array.t
-        val fields_set_array : t -> builder_t_Field_11145653318641710175 array -> (rw, builder_t_Field_11145653318641710175, array_t) Capnp.Array.t
-        val fields_init : t -> int -> (rw, builder_t_Field_11145653318641710175, array_t) Capnp.Array.t
+        val fields_get : t -> (rw, [`Field_9aad50a41f4af45f] builder_t, array_t) Capnp.Array.t
+        val fields_get_list : t -> [`Field_9aad50a41f4af45f] builder_t list
+        val fields_get_array : t -> [`Field_9aad50a41f4af45f] builder_t array
+        val fields_set : t -> (rw, [`Field_9aad50a41f4af45f] builder_t, array_t) Capnp.Array.t -> (rw, [`Field_9aad50a41f4af45f] builder_t, array_t) Capnp.Array.t
+        val fields_set_list : t -> [`Field_9aad50a41f4af45f] builder_t list -> (rw, [`Field_9aad50a41f4af45f] builder_t, array_t) Capnp.Array.t
+        val fields_set_array : t -> [`Field_9aad50a41f4af45f] builder_t array -> (rw, [`Field_9aad50a41f4af45f] builder_t, array_t) Capnp.Array.t
+        val fields_init : t -> int -> (rw, [`Field_9aad50a41f4af45f] builder_t, array_t) Capnp.Array.t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Enum : sig
-        type t = builder_t_Enum_13063450714778629528
-        type reader_t = reader_t_Enum_13063450714778629528
+        type struct_t = [`Enum_b54ab3364333f598]
+        type t = struct_t builder_t
         val has_enumerants : t -> bool
-        val enumerants_get : t -> (rw, builder_t_Enumerant_10919677598968879693, array_t) Capnp.Array.t
-        val enumerants_get_list : t -> builder_t_Enumerant_10919677598968879693 list
-        val enumerants_get_array : t -> builder_t_Enumerant_10919677598968879693 array
-        val enumerants_set : t -> (rw, builder_t_Enumerant_10919677598968879693, array_t) Capnp.Array.t -> (rw, builder_t_Enumerant_10919677598968879693, array_t) Capnp.Array.t
-        val enumerants_set_list : t -> builder_t_Enumerant_10919677598968879693 list -> (rw, builder_t_Enumerant_10919677598968879693, array_t) Capnp.Array.t
-        val enumerants_set_array : t -> builder_t_Enumerant_10919677598968879693 array -> (rw, builder_t_Enumerant_10919677598968879693, array_t) Capnp.Array.t
-        val enumerants_init : t -> int -> (rw, builder_t_Enumerant_10919677598968879693, array_t) Capnp.Array.t
+        val enumerants_get : t -> (rw, [`Enumerant_978a7cebdc549a4d] builder_t, array_t) Capnp.Array.t
+        val enumerants_get_list : t -> [`Enumerant_978a7cebdc549a4d] builder_t list
+        val enumerants_get_array : t -> [`Enumerant_978a7cebdc549a4d] builder_t array
+        val enumerants_set : t -> (rw, [`Enumerant_978a7cebdc549a4d] builder_t, array_t) Capnp.Array.t -> (rw, [`Enumerant_978a7cebdc549a4d] builder_t, array_t) Capnp.Array.t
+        val enumerants_set_list : t -> [`Enumerant_978a7cebdc549a4d] builder_t list -> (rw, [`Enumerant_978a7cebdc549a4d] builder_t, array_t) Capnp.Array.t
+        val enumerants_set_array : t -> [`Enumerant_978a7cebdc549a4d] builder_t array -> (rw, [`Enumerant_978a7cebdc549a4d] builder_t, array_t) Capnp.Array.t
+        val enumerants_init : t -> int -> (rw, [`Enumerant_978a7cebdc549a4d] builder_t, array_t) Capnp.Array.t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Interface : sig
-        type t = builder_t_Interface_16728431493453586831
-        type reader_t = reader_t_Interface_16728431493453586831
+        type struct_t = [`Interface_e82753cff0c2218f]
+        type t = struct_t builder_t
         val has_methods : t -> bool
-        val methods_get : t -> (rw, builder_t_Method_10736806783679155584, array_t) Capnp.Array.t
-        val methods_get_list : t -> builder_t_Method_10736806783679155584 list
-        val methods_get_array : t -> builder_t_Method_10736806783679155584 array
-        val methods_set : t -> (rw, builder_t_Method_10736806783679155584, array_t) Capnp.Array.t -> (rw, builder_t_Method_10736806783679155584, array_t) Capnp.Array.t
-        val methods_set_list : t -> builder_t_Method_10736806783679155584 list -> (rw, builder_t_Method_10736806783679155584, array_t) Capnp.Array.t
-        val methods_set_array : t -> builder_t_Method_10736806783679155584 array -> (rw, builder_t_Method_10736806783679155584, array_t) Capnp.Array.t
-        val methods_init : t -> int -> (rw, builder_t_Method_10736806783679155584, array_t) Capnp.Array.t
+        val methods_get : t -> (rw, [`Method_9500cce23b334d80] builder_t, array_t) Capnp.Array.t
+        val methods_get_list : t -> [`Method_9500cce23b334d80] builder_t list
+        val methods_get_array : t -> [`Method_9500cce23b334d80] builder_t array
+        val methods_set : t -> (rw, [`Method_9500cce23b334d80] builder_t, array_t) Capnp.Array.t -> (rw, [`Method_9500cce23b334d80] builder_t, array_t) Capnp.Array.t
+        val methods_set_list : t -> [`Method_9500cce23b334d80] builder_t list -> (rw, [`Method_9500cce23b334d80] builder_t, array_t) Capnp.Array.t
+        val methods_set_array : t -> [`Method_9500cce23b334d80] builder_t array -> (rw, [`Method_9500cce23b334d80] builder_t, array_t) Capnp.Array.t
+        val methods_init : t -> int -> (rw, [`Method_9500cce23b334d80] builder_t, array_t) Capnp.Array.t
         val has_superclasses : t -> bool
-        val superclasses_get : t -> (rw, builder_t_Superclass_12220001500510083064, array_t) Capnp.Array.t
-        val superclasses_get_list : t -> builder_t_Superclass_12220001500510083064 list
-        val superclasses_get_array : t -> builder_t_Superclass_12220001500510083064 array
-        val superclasses_set : t -> (rw, builder_t_Superclass_12220001500510083064, array_t) Capnp.Array.t -> (rw, builder_t_Superclass_12220001500510083064, array_t) Capnp.Array.t
-        val superclasses_set_list : t -> builder_t_Superclass_12220001500510083064 list -> (rw, builder_t_Superclass_12220001500510083064, array_t) Capnp.Array.t
-        val superclasses_set_array : t -> builder_t_Superclass_12220001500510083064 array -> (rw, builder_t_Superclass_12220001500510083064, array_t) Capnp.Array.t
-        val superclasses_init : t -> int -> (rw, builder_t_Superclass_12220001500510083064, array_t) Capnp.Array.t
+        val superclasses_get : t -> (rw, [`Superclass_a9962a9ed0a4d7f8] builder_t, array_t) Capnp.Array.t
+        val superclasses_get_list : t -> [`Superclass_a9962a9ed0a4d7f8] builder_t list
+        val superclasses_get_array : t -> [`Superclass_a9962a9ed0a4d7f8] builder_t array
+        val superclasses_set : t -> (rw, [`Superclass_a9962a9ed0a4d7f8] builder_t, array_t) Capnp.Array.t -> (rw, [`Superclass_a9962a9ed0a4d7f8] builder_t, array_t) Capnp.Array.t
+        val superclasses_set_list : t -> [`Superclass_a9962a9ed0a4d7f8] builder_t list -> (rw, [`Superclass_a9962a9ed0a4d7f8] builder_t, array_t) Capnp.Array.t
+        val superclasses_set_array : t -> [`Superclass_a9962a9ed0a4d7f8] builder_t array -> (rw, [`Superclass_a9962a9ed0a4d7f8] builder_t, array_t) Capnp.Array.t
+        val superclasses_init : t -> int -> (rw, [`Superclass_a9962a9ed0a4d7f8] builder_t, array_t) Capnp.Array.t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Const : sig
-        type t = builder_t_Const_12793219851699983392
-        type reader_t = reader_t_Const_12793219851699983392
+        type struct_t = [`Const_b18aa5ac7a0d9420]
+        type t = struct_t builder_t
         val has_type : t -> bool
-        val type_get : t -> builder_t_Type_15020482145304562784
-        val type_set_reader : t -> reader_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val type_set_builder : t -> builder_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val type_init : t -> builder_t_Type_15020482145304562784
+        val type_get : t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_set_reader : t -> [`Type_d07378ede1f9cc60] reader_t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_set_builder : t -> [`Type_d07378ede1f9cc60] builder_t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_init : t -> [`Type_d07378ede1f9cc60] builder_t
         val has_value : t -> bool
-        val value_get : t -> builder_t_Value_14853958794117909659
-        val value_set_reader : t -> reader_t_Value_14853958794117909659 -> builder_t_Value_14853958794117909659
-        val value_set_builder : t -> builder_t_Value_14853958794117909659 -> builder_t_Value_14853958794117909659
-        val value_init : t -> builder_t_Value_14853958794117909659
+        val value_get : t -> [`Value_ce23dcd2d7b00c9b] builder_t
+        val value_set_reader : t -> [`Value_ce23dcd2d7b00c9b] reader_t -> [`Value_ce23dcd2d7b00c9b] builder_t
+        val value_set_builder : t -> [`Value_ce23dcd2d7b00c9b] builder_t -> [`Value_ce23dcd2d7b00c9b] builder_t
+        val value_init : t -> [`Value_ce23dcd2d7b00c9b] builder_t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Annotation : sig
-        type t = builder_t_Annotation_17011813041836786320
-        type reader_t = reader_t_Annotation_17011813041836786320
+        type struct_t = [`Annotation_ec1619d4400a0290]
+        type t = struct_t builder_t
         val has_type : t -> bool
-        val type_get : t -> builder_t_Type_15020482145304562784
-        val type_set_reader : t -> reader_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val type_set_builder : t -> builder_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val type_init : t -> builder_t_Type_15020482145304562784
+        val type_get : t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_set_reader : t -> [`Type_d07378ede1f9cc60] reader_t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_set_builder : t -> [`Type_d07378ede1f9cc60] builder_t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_init : t -> [`Type_d07378ede1f9cc60] builder_t
         val targets_file_get : t -> bool
         val targets_file_set : t -> bool -> unit
         val targets_const_get : t -> bool
@@ -729,25 +630,25 @@ module type S = sig
         val targets_annotation_set : t -> bool -> unit
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Parameter : sig
-        type t = builder_t_Parameter_13353766412138554289
-        type reader_t = reader_t_Parameter_13353766412138554289
+        type struct_t = [`Parameter_b9521bccf10fa3b1]
+        type t = struct_t builder_t
         val has_name : t -> bool
         val name_get : t -> string
         val name_set : t -> string -> unit
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module NestedNode : sig
-        type t = builder_t_NestedNode_16050641862814319170
-        type reader_t = reader_t_NestedNode_16050641862814319170
+        type struct_t = [`NestedNode_debf55bbfa0fc242]
+        type t = struct_t builder_t
         val has_name : t -> bool
         val name_get : t -> string
         val name_set : t -> string -> unit
@@ -757,7 +658,7 @@ module type S = sig
         val id_set_int_exn : t -> int -> unit
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
@@ -792,81 +693,81 @@ module type S = sig
       val scope_id_set : t -> Uint64.t -> unit
       val scope_id_set_int_exn : t -> int -> unit
       val has_parameters : t -> bool
-      val parameters_get : t -> (rw, builder_t_Parameter_13353766412138554289, array_t) Capnp.Array.t
-      val parameters_get_list : t -> builder_t_Parameter_13353766412138554289 list
-      val parameters_get_array : t -> builder_t_Parameter_13353766412138554289 array
-      val parameters_set : t -> (rw, builder_t_Parameter_13353766412138554289, array_t) Capnp.Array.t -> (rw, builder_t_Parameter_13353766412138554289, array_t) Capnp.Array.t
-      val parameters_set_list : t -> builder_t_Parameter_13353766412138554289 list -> (rw, builder_t_Parameter_13353766412138554289, array_t) Capnp.Array.t
-      val parameters_set_array : t -> builder_t_Parameter_13353766412138554289 array -> (rw, builder_t_Parameter_13353766412138554289, array_t) Capnp.Array.t
-      val parameters_init : t -> int -> (rw, builder_t_Parameter_13353766412138554289, array_t) Capnp.Array.t
+      val parameters_get : t -> (rw, [`Parameter_b9521bccf10fa3b1] builder_t, array_t) Capnp.Array.t
+      val parameters_get_list : t -> [`Parameter_b9521bccf10fa3b1] builder_t list
+      val parameters_get_array : t -> [`Parameter_b9521bccf10fa3b1] builder_t array
+      val parameters_set : t -> (rw, [`Parameter_b9521bccf10fa3b1] builder_t, array_t) Capnp.Array.t -> (rw, [`Parameter_b9521bccf10fa3b1] builder_t, array_t) Capnp.Array.t
+      val parameters_set_list : t -> [`Parameter_b9521bccf10fa3b1] builder_t list -> (rw, [`Parameter_b9521bccf10fa3b1] builder_t, array_t) Capnp.Array.t
+      val parameters_set_array : t -> [`Parameter_b9521bccf10fa3b1] builder_t array -> (rw, [`Parameter_b9521bccf10fa3b1] builder_t, array_t) Capnp.Array.t
+      val parameters_init : t -> int -> (rw, [`Parameter_b9521bccf10fa3b1] builder_t, array_t) Capnp.Array.t
       val is_generic_get : t -> bool
       val is_generic_set : t -> bool -> unit
       val has_nested_nodes : t -> bool
-      val nested_nodes_get : t -> (rw, builder_t_NestedNode_16050641862814319170, array_t) Capnp.Array.t
-      val nested_nodes_get_list : t -> builder_t_NestedNode_16050641862814319170 list
-      val nested_nodes_get_array : t -> builder_t_NestedNode_16050641862814319170 array
-      val nested_nodes_set : t -> (rw, builder_t_NestedNode_16050641862814319170, array_t) Capnp.Array.t -> (rw, builder_t_NestedNode_16050641862814319170, array_t) Capnp.Array.t
-      val nested_nodes_set_list : t -> builder_t_NestedNode_16050641862814319170 list -> (rw, builder_t_NestedNode_16050641862814319170, array_t) Capnp.Array.t
-      val nested_nodes_set_array : t -> builder_t_NestedNode_16050641862814319170 array -> (rw, builder_t_NestedNode_16050641862814319170, array_t) Capnp.Array.t
-      val nested_nodes_init : t -> int -> (rw, builder_t_NestedNode_16050641862814319170, array_t) Capnp.Array.t
+      val nested_nodes_get : t -> (rw, [`NestedNode_debf55bbfa0fc242] builder_t, array_t) Capnp.Array.t
+      val nested_nodes_get_list : t -> [`NestedNode_debf55bbfa0fc242] builder_t list
+      val nested_nodes_get_array : t -> [`NestedNode_debf55bbfa0fc242] builder_t array
+      val nested_nodes_set : t -> (rw, [`NestedNode_debf55bbfa0fc242] builder_t, array_t) Capnp.Array.t -> (rw, [`NestedNode_debf55bbfa0fc242] builder_t, array_t) Capnp.Array.t
+      val nested_nodes_set_list : t -> [`NestedNode_debf55bbfa0fc242] builder_t list -> (rw, [`NestedNode_debf55bbfa0fc242] builder_t, array_t) Capnp.Array.t
+      val nested_nodes_set_array : t -> [`NestedNode_debf55bbfa0fc242] builder_t array -> (rw, [`NestedNode_debf55bbfa0fc242] builder_t, array_t) Capnp.Array.t
+      val nested_nodes_init : t -> int -> (rw, [`NestedNode_debf55bbfa0fc242] builder_t, array_t) Capnp.Array.t
       val has_annotations : t -> bool
-      val annotations_get : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> builder_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> builder_t_Annotation_17422339044421236034 array
-      val annotations_set : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_list : t -> builder_t_Annotation_17422339044421236034 list -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_array : t -> builder_t_Annotation_17422339044421236034 array -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_init : t -> int -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
+      val annotations_get : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] builder_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] builder_t array
+      val annotations_set : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_list : t -> [`Annotation_f1c8950dab257542] builder_t list -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_array : t -> [`Annotation_f1c8950dab257542] builder_t array -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_init : t -> int -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Field : sig
-      type t = builder_t_Field_11145653318641710175
-      type reader_t = reader_t_Field_11145653318641710175
+      type struct_t = [`Field_9aad50a41f4af45f]
+      type t = struct_t builder_t
       module Slot : sig
-        type t = builder_t_Slot_14133145859926553711
-        type reader_t = reader_t_Slot_14133145859926553711
+        type struct_t = [`Slot_c42305476bb4746f]
+        type t = struct_t builder_t
         val offset_get : t -> Uint32.t
         val offset_get_int_exn : t -> int
         val offset_set : t -> Uint32.t -> unit
         val offset_set_int_exn : t -> int -> unit
         val has_type : t -> bool
-        val type_get : t -> builder_t_Type_15020482145304562784
-        val type_set_reader : t -> reader_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val type_set_builder : t -> builder_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val type_init : t -> builder_t_Type_15020482145304562784
+        val type_get : t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_set_reader : t -> [`Type_d07378ede1f9cc60] reader_t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_set_builder : t -> [`Type_d07378ede1f9cc60] builder_t -> [`Type_d07378ede1f9cc60] builder_t
+        val type_init : t -> [`Type_d07378ede1f9cc60] builder_t
         val has_default_value : t -> bool
-        val default_value_get : t -> builder_t_Value_14853958794117909659
-        val default_value_set_reader : t -> reader_t_Value_14853958794117909659 -> builder_t_Value_14853958794117909659
-        val default_value_set_builder : t -> builder_t_Value_14853958794117909659 -> builder_t_Value_14853958794117909659
-        val default_value_init : t -> builder_t_Value_14853958794117909659
+        val default_value_get : t -> [`Value_ce23dcd2d7b00c9b] builder_t
+        val default_value_set_reader : t -> [`Value_ce23dcd2d7b00c9b] reader_t -> [`Value_ce23dcd2d7b00c9b] builder_t
+        val default_value_set_builder : t -> [`Value_ce23dcd2d7b00c9b] builder_t -> [`Value_ce23dcd2d7b00c9b] builder_t
+        val default_value_init : t -> [`Value_ce23dcd2d7b00c9b] builder_t
         val had_explicit_default_get : t -> bool
         val had_explicit_default_set : t -> bool -> unit
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Group : sig
-        type t = builder_t_Group_14626792032033250577
-        type reader_t = reader_t_Group_14626792032033250577
+        type struct_t = [`Group_cafccddb68db1d11]
+        type t = struct_t builder_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val type_id_set : t -> Uint64.t -> unit
         val type_id_set_int_exn : t -> int -> unit
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Ordinal : sig
-        type t = builder_t_Ordinal_13515537513213004774
-        type reader_t = reader_t_Ordinal_13515537513213004774
+        type struct_t = [`Ordinal_bb90d5c287870be6]
+        type t = struct_t builder_t
         type unnamed_union_t =
           | Implicit
           | Explicit of int
@@ -876,7 +777,7 @@ module type S = sig
         val explicit_set_exn : t -> int -> unit
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
@@ -894,66 +795,66 @@ module type S = sig
       val code_order_get : t -> int
       val code_order_set_exn : t -> int -> unit
       val has_annotations : t -> bool
-      val annotations_get : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> builder_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> builder_t_Annotation_17422339044421236034 array
-      val annotations_set : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_list : t -> builder_t_Annotation_17422339044421236034 list -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_array : t -> builder_t_Annotation_17422339044421236034 array -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_init : t -> int -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
+      val annotations_get : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] builder_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] builder_t array
+      val annotations_set : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_list : t -> [`Annotation_f1c8950dab257542] builder_t list -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_array : t -> [`Annotation_f1c8950dab257542] builder_t array -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_init : t -> int -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
       val discriminant_value_get : t -> int
       val discriminant_value_set_exn : t -> int -> unit
       val ordinal_get : t -> Ordinal.t
       val ordinal_init : t -> Ordinal.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Enumerant : sig
-      type t = builder_t_Enumerant_10919677598968879693
-      type reader_t = reader_t_Enumerant_10919677598968879693
+      type struct_t = [`Enumerant_978a7cebdc549a4d]
+      type t = struct_t builder_t
       val has_name : t -> bool
       val name_get : t -> string
       val name_set : t -> string -> unit
       val code_order_get : t -> int
       val code_order_set_exn : t -> int -> unit
       val has_annotations : t -> bool
-      val annotations_get : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> builder_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> builder_t_Annotation_17422339044421236034 array
-      val annotations_set : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_list : t -> builder_t_Annotation_17422339044421236034 list -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_array : t -> builder_t_Annotation_17422339044421236034 array -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_init : t -> int -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
+      val annotations_get : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] builder_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] builder_t array
+      val annotations_set : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_list : t -> [`Annotation_f1c8950dab257542] builder_t list -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_array : t -> [`Annotation_f1c8950dab257542] builder_t array -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_init : t -> int -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Superclass : sig
-      type t = builder_t_Superclass_12220001500510083064
-      type reader_t = reader_t_Superclass_12220001500510083064
+      type struct_t = [`Superclass_a9962a9ed0a4d7f8]
+      type t = struct_t builder_t
       val id_get : t -> Uint64.t
       val id_get_int_exn : t -> int
       val id_set : t -> Uint64.t -> unit
       val id_set_int_exn : t -> int -> unit
       val has_brand : t -> bool
-      val brand_get : t -> builder_t_Brand_10391024731148337707
-      val brand_set_reader : t -> reader_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-      val brand_set_builder : t -> builder_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-      val brand_init : t -> builder_t_Brand_10391024731148337707
+      val brand_get : t -> [`Brand_903455f06065422b] builder_t
+      val brand_set_reader : t -> [`Brand_903455f06065422b] reader_t -> [`Brand_903455f06065422b] builder_t
+      val brand_set_builder : t -> [`Brand_903455f06065422b] builder_t -> [`Brand_903455f06065422b] builder_t
+      val brand_init : t -> [`Brand_903455f06065422b] builder_t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Method : sig
-      type t = builder_t_Method_10736806783679155584
-      type reader_t = reader_t_Method_10736806783679155584
+      type struct_t = [`Method_9500cce23b334d80]
+      type t = struct_t builder_t
       val has_name : t -> bool
       val name_get : t -> string
       val name_set : t -> string -> unit
@@ -972,110 +873,110 @@ module type S = sig
       val param_struct_type_set : t -> Uint64.t -> unit
       val param_struct_type_set_int_exn : t -> int -> unit
       val has_param_brand : t -> bool
-      val param_brand_get : t -> builder_t_Brand_10391024731148337707
-      val param_brand_set_reader : t -> reader_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-      val param_brand_set_builder : t -> builder_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-      val param_brand_init : t -> builder_t_Brand_10391024731148337707
+      val param_brand_get : t -> [`Brand_903455f06065422b] builder_t
+      val param_brand_set_reader : t -> [`Brand_903455f06065422b] reader_t -> [`Brand_903455f06065422b] builder_t
+      val param_brand_set_builder : t -> [`Brand_903455f06065422b] builder_t -> [`Brand_903455f06065422b] builder_t
+      val param_brand_init : t -> [`Brand_903455f06065422b] builder_t
       val result_struct_type_get : t -> Uint64.t
       val result_struct_type_get_int_exn : t -> int
       val result_struct_type_set : t -> Uint64.t -> unit
       val result_struct_type_set_int_exn : t -> int -> unit
       val has_result_brand : t -> bool
-      val result_brand_get : t -> builder_t_Brand_10391024731148337707
-      val result_brand_set_reader : t -> reader_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-      val result_brand_set_builder : t -> builder_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-      val result_brand_init : t -> builder_t_Brand_10391024731148337707
+      val result_brand_get : t -> [`Brand_903455f06065422b] builder_t
+      val result_brand_set_reader : t -> [`Brand_903455f06065422b] reader_t -> [`Brand_903455f06065422b] builder_t
+      val result_brand_set_builder : t -> [`Brand_903455f06065422b] builder_t -> [`Brand_903455f06065422b] builder_t
+      val result_brand_init : t -> [`Brand_903455f06065422b] builder_t
       val has_annotations : t -> bool
-      val annotations_get : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_get_list : t -> builder_t_Annotation_17422339044421236034 list
-      val annotations_get_array : t -> builder_t_Annotation_17422339044421236034 array
-      val annotations_set : t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_list : t -> builder_t_Annotation_17422339044421236034 list -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_set_array : t -> builder_t_Annotation_17422339044421236034 array -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
-      val annotations_init : t -> int -> (rw, builder_t_Annotation_17422339044421236034, array_t) Capnp.Array.t
+      val annotations_get : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_get_list : t -> [`Annotation_f1c8950dab257542] builder_t list
+      val annotations_get_array : t -> [`Annotation_f1c8950dab257542] builder_t array
+      val annotations_set : t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_list : t -> [`Annotation_f1c8950dab257542] builder_t list -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_set_array : t -> [`Annotation_f1c8950dab257542] builder_t array -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
+      val annotations_init : t -> int -> (rw, [`Annotation_f1c8950dab257542] builder_t, array_t) Capnp.Array.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Type : sig
-      type t = builder_t_Type_15020482145304562784
-      type reader_t = reader_t_Type_15020482145304562784
+      type struct_t = [`Type_d07378ede1f9cc60]
+      type t = struct_t builder_t
       module List : sig
-        type t = builder_t_List_9792858745991129751
-        type reader_t = reader_t_List_9792858745991129751
+        type struct_t = [`List_87e739250a60ea97]
+        type t = struct_t builder_t
         val has_element_type : t -> bool
-        val element_type_get : t -> builder_t_Type_15020482145304562784
-        val element_type_set_reader : t -> reader_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val element_type_set_builder : t -> builder_t_Type_15020482145304562784 -> builder_t_Type_15020482145304562784
-        val element_type_init : t -> builder_t_Type_15020482145304562784
+        val element_type_get : t -> [`Type_d07378ede1f9cc60] builder_t
+        val element_type_set_reader : t -> [`Type_d07378ede1f9cc60] reader_t -> [`Type_d07378ede1f9cc60] builder_t
+        val element_type_set_builder : t -> [`Type_d07378ede1f9cc60] builder_t -> [`Type_d07378ede1f9cc60] builder_t
+        val element_type_init : t -> [`Type_d07378ede1f9cc60] builder_t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Enum : sig
-        type t = builder_t_Enum_11389172934837766057
-        type reader_t = reader_t_Enum_11389172934837766057
+        type struct_t = [`Enum_9e0e78711a7f87a9]
+        type t = struct_t builder_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val type_id_set : t -> Uint64.t -> unit
         val type_id_set_int_exn : t -> int -> unit
         val has_brand : t -> bool
-        val brand_get : t -> builder_t_Brand_10391024731148337707
-        val brand_set_reader : t -> reader_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-        val brand_set_builder : t -> builder_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-        val brand_init : t -> builder_t_Brand_10391024731148337707
+        val brand_get : t -> [`Brand_903455f06065422b] builder_t
+        val brand_set_reader : t -> [`Brand_903455f06065422b] reader_t -> [`Brand_903455f06065422b] builder_t
+        val brand_set_builder : t -> [`Brand_903455f06065422b] builder_t -> [`Brand_903455f06065422b] builder_t
+        val brand_init : t -> [`Brand_903455f06065422b] builder_t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Struct : sig
-        type t = builder_t_Struct_12410354185295152851
-        type reader_t = reader_t_Struct_12410354185295152851
+        type struct_t = [`Struct_ac3a6f60ef4cc6d3]
+        type t = struct_t builder_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val type_id_set : t -> Uint64.t -> unit
         val type_id_set_int_exn : t -> int -> unit
         val has_brand : t -> bool
-        val brand_get : t -> builder_t_Brand_10391024731148337707
-        val brand_set_reader : t -> reader_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-        val brand_set_builder : t -> builder_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-        val brand_init : t -> builder_t_Brand_10391024731148337707
+        val brand_get : t -> [`Brand_903455f06065422b] builder_t
+        val brand_set_reader : t -> [`Brand_903455f06065422b] reader_t -> [`Brand_903455f06065422b] builder_t
+        val brand_set_builder : t -> [`Brand_903455f06065422b] builder_t -> [`Brand_903455f06065422b] builder_t
+        val brand_init : t -> [`Brand_903455f06065422b] builder_t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Interface : sig
-        type t = builder_t_Interface_17116997365232503999
-        type reader_t = reader_t_Interface_17116997365232503999
+        type struct_t = [`Interface_ed8bca69f7fb0cbf]
+        type t = struct_t builder_t
         val type_id_get : t -> Uint64.t
         val type_id_get_int_exn : t -> int
         val type_id_set : t -> Uint64.t -> unit
         val type_id_set_int_exn : t -> int -> unit
         val has_brand : t -> bool
-        val brand_get : t -> builder_t_Brand_10391024731148337707
-        val brand_set_reader : t -> reader_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-        val brand_set_builder : t -> builder_t_Brand_10391024731148337707 -> builder_t_Brand_10391024731148337707
-        val brand_init : t -> builder_t_Brand_10391024731148337707
+        val brand_get : t -> [`Brand_903455f06065422b] builder_t
+        val brand_set_reader : t -> [`Brand_903455f06065422b] reader_t -> [`Brand_903455f06065422b] builder_t
+        val brand_set_builder : t -> [`Brand_903455f06065422b] builder_t -> [`Brand_903455f06065422b] builder_t
+        val brand_init : t -> [`Brand_903455f06065422b] builder_t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module AnyPointer : sig
-        type t = builder_t_AnyPointer_14003731834718800369
-        type reader_t = reader_t_AnyPointer_14003731834718800369
+        type struct_t = [`AnyPointer_c2573fe8a23e49f1]
+        type t = struct_t builder_t
         module Unconstrained : sig
-          type t = builder_t_Unconstrained_10248890354574636630
-          type reader_t = reader_t_Unconstrained_10248890354574636630
+          type struct_t = [`Unconstrained_8e3b5f79fe593656]
+          type t = struct_t builder_t
           type unnamed_union_t =
             | AnyKind
             | Struct
@@ -1089,13 +990,13 @@ module type S = sig
           val capability_set : t -> unit
           val of_message : rw message_t -> t
           val to_message : t -> rw message_t
-          val to_reader : t -> reader_t
+          val to_reader : t -> struct_t reader_t
           val init_root : ?message_size:int -> unit -> t
           val init_pointer : pointer_t -> t
         end
         module Parameter : sig
-          type t = builder_t_Parameter_11372142272178113157
-          type reader_t = reader_t_Parameter_11372142272178113157
+          type struct_t = [`Parameter_9dd1f724f4614a85]
+          type t = struct_t builder_t
           val scope_id_get : t -> Uint64.t
           val scope_id_get_int_exn : t -> int
           val scope_id_set : t -> Uint64.t -> unit
@@ -1104,18 +1005,18 @@ module type S = sig
           val parameter_index_set_exn : t -> int -> unit
           val of_message : rw message_t -> t
           val to_message : t -> rw message_t
-          val to_reader : t -> reader_t
+          val to_reader : t -> struct_t reader_t
           val init_root : ?message_size:int -> unit -> t
           val init_pointer : pointer_t -> t
         end
         module ImplicitMethodParameter : sig
-          type t = builder_t_ImplicitMethodParameter_13470206089842057844
-          type reader_t = reader_t_ImplicitMethodParameter_13470206089842057844
+          type struct_t = [`ImplicitMethodParameter_baefc9120c56e274]
+          type t = struct_t builder_t
           val parameter_index_get : t -> int
           val parameter_index_set_exn : t -> int -> unit
           val of_message : rw message_t -> t
           val to_message : t -> rw message_t
-          val to_reader : t -> reader_t
+          val to_reader : t -> struct_t reader_t
           val init_root : ?message_size:int -> unit -> t
           val init_pointer : pointer_t -> t
         end
@@ -1130,7 +1031,7 @@ module type S = sig
         val implicit_method_parameter_init : t -> ImplicitMethodParameter.t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
@@ -1177,25 +1078,25 @@ module type S = sig
       val any_pointer_init : t -> AnyPointer.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Brand : sig
-      type t = builder_t_Brand_10391024731148337707
-      type reader_t = reader_t_Brand_10391024731148337707
+      type struct_t = [`Brand_903455f06065422b]
+      type t = struct_t builder_t
       module Scope : sig
-        type t = builder_t_Scope_12382423449155627977
-        type reader_t = reader_t_Scope_12382423449155627977
+        type struct_t = [`Scope_abd73485a9636bc9]
+        type t = struct_t builder_t
         type unnamed_union_t =
-          | Bind of (rw, builder_t_Binding_14439610327179913212, array_t) Capnp.Array.t
+          | Bind of (rw, [`Binding_c863cd16969ee7fc] builder_t, array_t) Capnp.Array.t
           | Inherit
           | Undefined of int
         val get : t -> unnamed_union_t
-        val bind_set : t -> (rw, builder_t_Binding_14439610327179913212, array_t) Capnp.Array.t -> (rw, builder_t_Binding_14439610327179913212, array_t) Capnp.Array.t
-        val bind_set_list : t -> builder_t_Binding_14439610327179913212 list -> (rw, builder_t_Binding_14439610327179913212, array_t) Capnp.Array.t
-        val bind_set_array : t -> builder_t_Binding_14439610327179913212 array -> (rw, builder_t_Binding_14439610327179913212, array_t) Capnp.Array.t
-        val bind_init : t -> int -> (rw, builder_t_Binding_14439610327179913212, array_t) Capnp.Array.t
+        val bind_set : t -> (rw, [`Binding_c863cd16969ee7fc] builder_t, array_t) Capnp.Array.t -> (rw, [`Binding_c863cd16969ee7fc] builder_t, array_t) Capnp.Array.t
+        val bind_set_list : t -> [`Binding_c863cd16969ee7fc] builder_t list -> (rw, [`Binding_c863cd16969ee7fc] builder_t, array_t) Capnp.Array.t
+        val bind_set_array : t -> [`Binding_c863cd16969ee7fc] builder_t array -> (rw, [`Binding_c863cd16969ee7fc] builder_t, array_t) Capnp.Array.t
+        val bind_init : t -> int -> (rw, [`Binding_c863cd16969ee7fc] builder_t, array_t) Capnp.Array.t
         val inherit_set : t -> unit
         val scope_id_get : t -> Uint64.t
         val scope_id_get_int_exn : t -> int
@@ -1203,45 +1104,45 @@ module type S = sig
         val scope_id_set_int_exn : t -> int -> unit
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       module Binding : sig
-        type t = builder_t_Binding_14439610327179913212
-        type reader_t = reader_t_Binding_14439610327179913212
+        type struct_t = [`Binding_c863cd16969ee7fc]
+        type t = struct_t builder_t
         type unnamed_union_t =
           | Unbound
           | Type of Type.t
           | Undefined of int
         val get : t -> unnamed_union_t
         val unbound_set : t -> unit
-        val type_set_reader : t -> Type.reader_t -> Type.t
+        val type_set_reader : t -> Type.struct_t reader_t -> Type.t
         val type_set_builder : t -> Type.t -> Type.t
         val type_init : t -> Type.t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       val has_scopes : t -> bool
-      val scopes_get : t -> (rw, builder_t_Scope_12382423449155627977, array_t) Capnp.Array.t
-      val scopes_get_list : t -> builder_t_Scope_12382423449155627977 list
-      val scopes_get_array : t -> builder_t_Scope_12382423449155627977 array
-      val scopes_set : t -> (rw, builder_t_Scope_12382423449155627977, array_t) Capnp.Array.t -> (rw, builder_t_Scope_12382423449155627977, array_t) Capnp.Array.t
-      val scopes_set_list : t -> builder_t_Scope_12382423449155627977 list -> (rw, builder_t_Scope_12382423449155627977, array_t) Capnp.Array.t
-      val scopes_set_array : t -> builder_t_Scope_12382423449155627977 array -> (rw, builder_t_Scope_12382423449155627977, array_t) Capnp.Array.t
-      val scopes_init : t -> int -> (rw, builder_t_Scope_12382423449155627977, array_t) Capnp.Array.t
+      val scopes_get : t -> (rw, [`Scope_abd73485a9636bc9] builder_t, array_t) Capnp.Array.t
+      val scopes_get_list : t -> [`Scope_abd73485a9636bc9] builder_t list
+      val scopes_get_array : t -> [`Scope_abd73485a9636bc9] builder_t array
+      val scopes_set : t -> (rw, [`Scope_abd73485a9636bc9] builder_t, array_t) Capnp.Array.t -> (rw, [`Scope_abd73485a9636bc9] builder_t, array_t) Capnp.Array.t
+      val scopes_set_list : t -> [`Scope_abd73485a9636bc9] builder_t list -> (rw, [`Scope_abd73485a9636bc9] builder_t, array_t) Capnp.Array.t
+      val scopes_set_array : t -> [`Scope_abd73485a9636bc9] builder_t array -> (rw, [`Scope_abd73485a9636bc9] builder_t, array_t) Capnp.Array.t
+      val scopes_init : t -> int -> (rw, [`Scope_abd73485a9636bc9] builder_t, array_t) Capnp.Array.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Value : sig
-      type t = builder_t_Value_14853958794117909659
-      type reader_t = reader_t_Value_14853958794117909659
+      type struct_t = [`Value_ce23dcd2d7b00c9b]
+      type t = struct_t builder_t
       type unnamed_union_t =
         | Void
         | Bool of bool
@@ -1295,30 +1196,30 @@ module type S = sig
       val any_pointer_set_interface : t -> Uint32.t option -> unit
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module Annotation : sig
-      type t = builder_t_Annotation_17422339044421236034
-      type reader_t = reader_t_Annotation_17422339044421236034
+      type struct_t = [`Annotation_f1c8950dab257542]
+      type t = struct_t builder_t
       val id_get : t -> Uint64.t
       val id_get_int_exn : t -> int
       val id_set : t -> Uint64.t -> unit
       val id_set_int_exn : t -> int -> unit
       val has_brand : t -> bool
       val brand_get : t -> Brand.t
-      val brand_set_reader : t -> Brand.reader_t -> Brand.t
+      val brand_set_reader : t -> Brand.struct_t reader_t -> Brand.t
       val brand_set_builder : t -> Brand.t -> Brand.t
       val brand_init : t -> Brand.t
       val has_value : t -> bool
       val value_get : t -> Value.t
-      val value_set_reader : t -> Value.reader_t -> Value.t
+      val value_set_reader : t -> Value.struct_t reader_t -> Value.t
       val value_set_builder : t -> Value.t -> Value.t
       val value_init : t -> Value.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
@@ -1335,8 +1236,8 @@ module type S = sig
         | Undefined of int
     end
     module CapnpVersion : sig
-      type t = builder_t_CapnpVersion_15590670654532458851
-      type reader_t = reader_t_CapnpVersion_15590670654532458851
+      type struct_t = [`CapnpVersion_d85d305b7d839963]
+      type t = struct_t builder_t
       val major_get : t -> int
       val major_set_exn : t -> int -> unit
       val minor_get : t -> int
@@ -1345,19 +1246,19 @@ module type S = sig
       val micro_set_exn : t -> int -> unit
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end
     module CodeGeneratorRequest : sig
-      type t = builder_t_CodeGeneratorRequest_13818529054586492878
-      type reader_t = reader_t_CodeGeneratorRequest_13818529054586492878
+      type struct_t = [`CodeGeneratorRequest_bfc546f6210ad7ce]
+      type t = struct_t builder_t
       module RequestedFile : sig
-        type t = builder_t_RequestedFile_14981803260258615394
-        type reader_t = reader_t_RequestedFile_14981803260258615394
+        type struct_t = [`RequestedFile_cfea0eb02e810062]
+        type t = struct_t builder_t
         module Import : sig
-          type t = builder_t_Import_12560611460656617445
-          type reader_t = reader_t_Import_12560611460656617445
+          type struct_t = [`Import_ae504193122357e5]
+          type t = struct_t builder_t
           val id_get : t -> Uint64.t
           val id_get_int_exn : t -> int
           val id_set : t -> Uint64.t -> unit
@@ -1367,7 +1268,7 @@ module type S = sig
           val name_set : t -> string -> unit
           val of_message : rw message_t -> t
           val to_message : t -> rw message_t
-          val to_reader : t -> reader_t
+          val to_reader : t -> struct_t reader_t
           val init_root : ?message_size:int -> unit -> t
           val init_pointer : pointer_t -> t
         end
@@ -1379,22 +1280,22 @@ module type S = sig
         val filename_get : t -> string
         val filename_set : t -> string -> unit
         val has_imports : t -> bool
-        val imports_get : t -> (rw, builder_t_Import_12560611460656617445, array_t) Capnp.Array.t
-        val imports_get_list : t -> builder_t_Import_12560611460656617445 list
-        val imports_get_array : t -> builder_t_Import_12560611460656617445 array
-        val imports_set : t -> (rw, builder_t_Import_12560611460656617445, array_t) Capnp.Array.t -> (rw, builder_t_Import_12560611460656617445, array_t) Capnp.Array.t
-        val imports_set_list : t -> builder_t_Import_12560611460656617445 list -> (rw, builder_t_Import_12560611460656617445, array_t) Capnp.Array.t
-        val imports_set_array : t -> builder_t_Import_12560611460656617445 array -> (rw, builder_t_Import_12560611460656617445, array_t) Capnp.Array.t
-        val imports_init : t -> int -> (rw, builder_t_Import_12560611460656617445, array_t) Capnp.Array.t
+        val imports_get : t -> (rw, [`Import_ae504193122357e5] builder_t, array_t) Capnp.Array.t
+        val imports_get_list : t -> [`Import_ae504193122357e5] builder_t list
+        val imports_get_array : t -> [`Import_ae504193122357e5] builder_t array
+        val imports_set : t -> (rw, [`Import_ae504193122357e5] builder_t, array_t) Capnp.Array.t -> (rw, [`Import_ae504193122357e5] builder_t, array_t) Capnp.Array.t
+        val imports_set_list : t -> [`Import_ae504193122357e5] builder_t list -> (rw, [`Import_ae504193122357e5] builder_t, array_t) Capnp.Array.t
+        val imports_set_array : t -> [`Import_ae504193122357e5] builder_t array -> (rw, [`Import_ae504193122357e5] builder_t, array_t) Capnp.Array.t
+        val imports_init : t -> int -> (rw, [`Import_ae504193122357e5] builder_t, array_t) Capnp.Array.t
         val of_message : rw message_t -> t
         val to_message : t -> rw message_t
-        val to_reader : t -> reader_t
+        val to_reader : t -> struct_t reader_t
         val init_root : ?message_size:int -> unit -> t
         val init_pointer : pointer_t -> t
       end
       val has_capnp_version : t -> bool
       val capnp_version_get : t -> CapnpVersion.t
-      val capnp_version_set_reader : t -> CapnpVersion.reader_t -> CapnpVersion.t
+      val capnp_version_set_reader : t -> CapnpVersion.struct_t reader_t -> CapnpVersion.t
       val capnp_version_set_builder : t -> CapnpVersion.t -> CapnpVersion.t
       val capnp_version_init : t -> CapnpVersion.t
       val has_nodes : t -> bool
@@ -1406,16 +1307,16 @@ module type S = sig
       val nodes_set_array : t -> Node.t array -> (rw, Node.t, array_t) Capnp.Array.t
       val nodes_init : t -> int -> (rw, Node.t, array_t) Capnp.Array.t
       val has_requested_files : t -> bool
-      val requested_files_get : t -> (rw, builder_t_RequestedFile_14981803260258615394, array_t) Capnp.Array.t
-      val requested_files_get_list : t -> builder_t_RequestedFile_14981803260258615394 list
-      val requested_files_get_array : t -> builder_t_RequestedFile_14981803260258615394 array
-      val requested_files_set : t -> (rw, builder_t_RequestedFile_14981803260258615394, array_t) Capnp.Array.t -> (rw, builder_t_RequestedFile_14981803260258615394, array_t) Capnp.Array.t
-      val requested_files_set_list : t -> builder_t_RequestedFile_14981803260258615394 list -> (rw, builder_t_RequestedFile_14981803260258615394, array_t) Capnp.Array.t
-      val requested_files_set_array : t -> builder_t_RequestedFile_14981803260258615394 array -> (rw, builder_t_RequestedFile_14981803260258615394, array_t) Capnp.Array.t
-      val requested_files_init : t -> int -> (rw, builder_t_RequestedFile_14981803260258615394, array_t) Capnp.Array.t
+      val requested_files_get : t -> (rw, [`RequestedFile_cfea0eb02e810062] builder_t, array_t) Capnp.Array.t
+      val requested_files_get_list : t -> [`RequestedFile_cfea0eb02e810062] builder_t list
+      val requested_files_get_array : t -> [`RequestedFile_cfea0eb02e810062] builder_t array
+      val requested_files_set : t -> (rw, [`RequestedFile_cfea0eb02e810062] builder_t, array_t) Capnp.Array.t -> (rw, [`RequestedFile_cfea0eb02e810062] builder_t, array_t) Capnp.Array.t
+      val requested_files_set_list : t -> [`RequestedFile_cfea0eb02e810062] builder_t list -> (rw, [`RequestedFile_cfea0eb02e810062] builder_t, array_t) Capnp.Array.t
+      val requested_files_set_array : t -> [`RequestedFile_cfea0eb02e810062] builder_t array -> (rw, [`RequestedFile_cfea0eb02e810062] builder_t, array_t) Capnp.Array.t
+      val requested_files_init : t -> int -> (rw, [`RequestedFile_cfea0eb02e810062] builder_t, array_t) Capnp.Array.t
       val of_message : rw message_t -> t
       val to_message : t -> rw message_t
-      val to_reader : t -> reader_t
+      val to_reader : t -> struct_t reader_t
       val init_root : ?message_size:int -> unit -> t
       val init_pointer : pointer_t -> t
     end

--- a/src/runtime/message.ml
+++ b/src/runtime/message.ml
@@ -360,6 +360,9 @@ module Make (Storage : MessageStorage.S) = struct
     type 'a builder_t = (rw, 'a) t
 
     let cast_reader x = (x :> 'a reader_t)
+
+    let reader_of_builder x = Some (readonly x)
+    let message_of_builder x = x.data.Slice.msg
   end
 
   module ListStorage = struct

--- a/src/runtime/messageSig.ml
+++ b/src/runtime/messageSig.ml
@@ -291,6 +291,9 @@ module type S = sig
     type 'a reader_t = (ro, 'a) t option
     type 'a builder_t = (rw, 'a) t
 
+    val reader_of_builder : 'a builder_t -> 'a reader_t
+    val message_of_builder : _ builder_t -> rw Message.t
+
     val cast_reader : 'a reader_t -> 'b reader_t
   end
 

--- a/src/tests/jbuild
+++ b/src/tests/jbuild
@@ -8,28 +8,28 @@
 
 (rule
  ((targets (test.ml test.mli))
-  (deps (test.capnp ../compiler/main.exe))
-  (action  (run capnpc -o ../compiler/main.exe ${<}))))
+  (deps (test.capnp ../compiler/main.bc))
+  (action  (run capnpc -o ../compiler/main.bc ${<}))))
 
 (rule
  ((targets (test_import.ml test_import.mli))
-  (deps (test-import.capnp ../compiler/main.exe))
-  (action  (run capnpc -o ../compiler/main.exe ${<}))))
+  (deps (test-import.capnp ../compiler/main.bc))
+  (action  (run capnpc -o ../compiler/main.bc ${<}))))
 
 (rule
  ((targets (c2b2b.ml c2b2b.mli))
-  (deps (c++.capnp ../compiler/main.exe))
-  (action  (run capnpc -o ../compiler/main.exe ${<}))))
+  (deps (c++.capnp ../compiler/main.bc))
+  (action  (run capnpc -o ../compiler/main.bc ${<}))))
 
 (rule
  ((targets (testLists.ml testLists.mli))
-  (deps (testLists.capnp ../compiler/main.exe))
-  (action  (run capnpc -o ../compiler/main.exe ${<}))))
+  (deps (testLists.capnp ../compiler/main.bc))
+  (action  (run capnpc -o ../compiler/main.bc ${<}))))
 
 (rule
  ((targets (testCycles.ml testCycles.mli))
-  (deps (testCycles.capnp ../compiler/main.exe))
-  (action  (run capnpc -o ../compiler/main.exe ${<}))))
+  (deps (testCycles.capnp ../compiler/main.bc))
+  (action  (run capnpc -o ../compiler/main.bc ${<}))))
 
 (alias
  ((name    runtest)


### PR DESCRIPTION
Instead of declaring a load of unique type names at the start of the file, use polymorphic variants. These don't need to be declared before use.

e.g.

    type struct_Foo_11668594054516559475
    type reader_t_Foo_11668594054516559475 = struct_Foo_11668594054516559475 reader_t
    type builder_t_Foo_11668594054516559475 = struct_Foo_11668594054516559475 builder_t

    module Foo : sig
      type t = reader_t_Foo_11668594054516559475
      type builder_t = builder_t_Foo_11668594054516559475
      val of_builder : builder_t -> t

becomes

    module Foo : sig
      type struct_t = [`Foo_a1ef2c783fb1ce73]
      type t = struct_t reader_t
      val of_builder : struct_t builder_t -> t

This simplifies imports (all uses of `Obj.magic` have been removed from the generated code).

It also makes it possible to refer to a type before applying the generated code's functor. This might be useful for the RPC system, as it allows it to define a capability as something that takes a request struct, before applying the RPC schema's functor (that defines what a request struct is).

I also switched to formatting the node ID as hex, to make it shorter and to match the format used in the schema files.

Note that there is a slight API change here, because the `$Struct.reader_t` and `$Struct.builder_t` types have gone (to avoid confusion with the generic `reader_t` and `builder_t` types). You have to use `struct_t reader_t` and `struct_t builder_t` instead.

To make writing generic code simpler, there are two new helpers in `StructStorage`:

    val reader_of_builder : 'a builder_t -> 'a reader_t
    val message_of_builder : _ builder_t -> rw Message.t

This required some changes to the benchmark code, but the new code is shorter (`6 files changed, 29 insertions(+), 57 deletions(-)`).