### PR TITLE
Generate code for methods

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -363,6 +363,107 @@ val init_root : ?message_size:int -> unit -> Bar.t
 val to_message : t -> rw message_t
 --------------------------------------------------------------------------------
 
+Interfaces
+~~~~~~~~~~
+
+A struct field `foo` which is of interface type will result in generation of
+the following accessors:
+[source,ocaml]
+--------------------------------------------------------------------------------
+(* Assuming that field foo contains interfaces of type Foo... *)
+
+val foo_get : t -> Uint32.t option
+val foo_set : t -> Uint32.t option -> unit
+--------------------------------------------------------------------------------
+
+Each interface `Foo` generates a module `Foo`. There will be one submodule for
+each method, with `Params` and `Results` submodules for any implicit structs
+needed for the method arguments and results:
+
+[source,ocaml]
+--------------------------------------------------------------------------------
+module Reader : sig
+  module Foo : sig
+    type t = [`Foo_c36d76740ee15e68]
+    module MyMethod : sig
+      module Params : sig
+        type struct_t = [`MyMethod_b104a8c98610c556]
+        type t = struct_t reader_t
+        val arg1_get : t -> string
+        [...]
+      end
+      module Results : sig
+        type struct_t = [`MyMethod_c6367b042fce8e87]
+        type t = struct_t reader_t
+        val result_get : t -> string
+        [...]
+      end
+    end
+  end
+end
+--------------------------------------------------------------------------------
+
+[source,ocaml]
+--------------------------------------------------------------------------------
+module Builder : sig
+  module Foo : sig
+    type t = [`Foo_c36d76740ee15e68]
+    module MyMethod : sig
+      module Params : sig
+	type struct_t = [`MyMethod_b104a8c98610c556]
+	type t = struct_t builder_t
+	val arg1_set : t -> string -> unit
+        [...]
+      end
+      module Results : sig
+	type struct_t = [`MyMethod_c6367b042fce8e87]
+	type t = struct_t builder_t
+	val result_set : t -> string -> unit
+        [...]
+      end
+    end
+  end
+end
+--------------------------------------------------------------------------------
+
+The generated file will also contain `Client` and `Service` top-level modules:
+
+
+[source,ocaml]
+--------------------------------------------------------------------------------
+  module Client : sig
+    module Foo : sig
+      type t = [`Foo_c36d76740ee15e68]
+      val interface_id : Uint64.t
+      module MyMethod : sig
+        module Params = Builder.Foo.MyMethod.Params
+        module Results = Reader.Foo.MyMethod.Results
+        val method_id : (t, Params.t, Results.t) Capnp.RPC.MethodID.t
+      end
+    end
+  end
+
+  module Service : sig
+    module Foo : sig
+      type t = [`Foo_c36d76740ee15e68]
+      val interface_id : Uint64.t
+      module MyMethod : sig
+        module Params = Reader.Foo.MyMethod.Params
+        module Results = Builder.Foo.MyMethod.Results
+      end
+    end
+  end
+--------------------------------------------------------------------------------
+
+The `Client` module is for use by clients. Each method links to a *builder* for
+the parameters and a *reader* for the results (in the `Service` section they are
+the other way around). The client section also includes the method's globally-unique
+ID. This is just a `(Uint64.t * int)` pair, but its type gives the type of the
+interface and of the request and response structs.
+
+Inheritance is not currently supported.
+
+
 Generating Code
 ---------------
 You will need to

--- a/src/runtime/capnp.ml
+++ b/src/runtime/capnp.ml
@@ -34,6 +34,7 @@ module BytesStorage = BytesStorage
 module BytesMessage = Message.BytesMessage
 module Codecs       = Codecs
 module IO           = IO
+module RPC          = RPC
 module Runtime = struct
   module BuilderInc      = BuilderInc
   module BuilderOps      = BuilderOps

--- a/src/runtime/rPC.ml
+++ b/src/runtime/rPC.ml
@@ -1,0 +1,58 @@
+module Registry : sig
+  (** Handy central registry of all known interfaces, for logging. *)
+
+  (** Used in the generated code to register the interfaces. *)
+  val register : interface_id:Uint64.t -> name:string -> (int -> string option) -> unit
+
+  (** [pp_method] is a formatter for [(interface_id, method_id)] pairs.
+      It prints out qualified names, suitable for logging
+      (e.g. "Foo.bar") *)
+  val pp_method : Format.formatter -> Uint64.t * int -> unit
+end = struct
+  type interface = {
+    name : string;
+    method_lookup : int -> string option;
+  }
+
+  let interfaces = Hashtbl.create 7
+
+  let register ~interface_id ~name method_lookup =
+    Hashtbl.add interfaces interface_id {name; method_lookup}
+
+  let pp_method f (interface_id, method_id) =
+    match Hashtbl.find interfaces interface_id with
+    | exception Not_found ->
+      Format.fprintf f "<interface %a>.<method-%d>"
+        Uint64.printer interface_id
+        method_id
+    | interface ->
+      match interface.method_lookup method_id with
+      | Some method_name ->
+        Format.fprintf f "%s.%s" interface.name method_name
+      | None ->
+        Format.fprintf f "%s.<method-%d>" interface.name method_id
+end
+
+module MethodID : sig
+  (** A globally unique method ID, for a method on the interface ['interface],
+      which takes parameters of type ['request] and produces results of type
+      ['response]. *)
+  type ('interface, 'request, 'response) t
+
+  val v : interface_id:Uint64.t -> method_id:int -> ('interface, 'req, 'resp) t
+
+  val interface_id : (_, _, _) t -> Uint64.t
+
+  val method_id : (_, _, _) t -> int
+
+  val pp : Format.formatter -> (_, _, _) t -> unit
+end = struct
+  type ('interface, 'request, 'response) t = Uint64.t * int
+
+  let v ~interface_id ~method_id = (interface_id, method_id)
+
+  let interface_id : (_, _, _) t -> Uint64.t = fst
+  let method_id : (_, _, _) t -> int = snd
+
+  let pp t = Registry.pp_method t
+end


### PR DESCRIPTION
Readers and builders for the implicit parameters and results structures are now generated.

A new `Client` module contains a sub-module for each interface, with a sub-module for each method. Each method contains `Params` and `Results` sub-module aliases (params to a builder, results to a reader) and the method ID.

A new `Service` module provides a similar structure for service authors, but where `Params` is a reader and `Results` is a builder.