### PR TITLE
Mirage unikernel support

### DIFF
--- a/capnp.opam
+++ b/capnp.opam
@@ -11,6 +11,7 @@ build-test: ["jbuilder" "build" "@runtest" "@src/benchmark/benchmarks"]
 
 depends: [
   "jbuilder" {build}
+  "result"
   "core_kernel" {>= "112.24.00"}
   "extunix"
   "ocplib-endian" {>= "0.7"}

--- a/src/benchmark/jbuild
+++ b/src/benchmark/jbuild
@@ -6,7 +6,7 @@ let config = {|
 
 (executable
  ((name main)
-  (libraries (capnp fast_rand core))
+  (libraries (capnp capnp_unix fast_rand core))
   (flags (:standard -w -53-55))
   (ocamlopt_flags (:standard # -inline 2000))
 ))

--- a/src/benchmark/methods.ml
+++ b/src/benchmark/methods.ml
@@ -2,7 +2,7 @@
 
 module CamlBytes = Bytes
 open Core.Std
-module IO = Capnp.IO
+module IO = Capnp_unix.IO
 module Codecs = Capnp.Codecs
 
 let message_of_builder = Capnp.BytesMessage.StructStorage.message_of_builder

--- a/src/compiler/jbuild
+++ b/src/compiler/jbuild
@@ -4,5 +4,5 @@
  ((name main)
   (public_name capnpc-ocaml)
   (flags (:standard -w -53-55))
-  (libraries (capnp))
+  (libraries (capnp capnp_unix))
 ))

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -33,6 +33,7 @@ open Capnp
 
 module M  = BytesMessage
 module PS = GenCommon.PS
+module IO = Capnp_unix.IO
 
 module ExitCode = struct
   let success       = 0

--- a/src/runtime/builderInc.ml
+++ b/src/runtime/builderInc.ml
@@ -34,8 +34,6 @@
    pointer will cause struct storage to be immediately allocated if that pointer
    was null). *)
 
-open Core_kernel.Std
-
 type ro = Message.ro
 type rw = Message.rw
 let invalid_msg = Message.invalid_msg
@@ -276,7 +274,7 @@ module Make (NM : RPC.S) = struct
         : int32 =
       let data = struct_storage.NM.StructStorage.data in
       let numeric = NM.Slice.get_int32 data byte_ofs in
-      Int32.bit_xor numeric default
+      Int32.logxor numeric default
 
     let get_int64
         ~(default : int64)
@@ -285,7 +283,7 @@ module Make (NM : RPC.S) = struct
       : int64 =
       let data = struct_storage.NM.StructStorage.data in
       let numeric = NM.Slice.get_int64 data byte_ofs in
-      Int64.bit_xor numeric default
+      Int64.logxor numeric default
 
     let get_uint8
         ~(default : int)
@@ -330,7 +328,7 @@ module Make (NM : RPC.S) = struct
       : float =
       let data = struct_storage.NM.StructStorage.data in
       let numeric = NM.Slice.get_int32 data byte_ofs in
-      let bits = Int32.bit_xor numeric default_bits in
+      let bits = Int32.logxor numeric default_bits in
       Int32.float_of_bits bits
 
     let get_float64
@@ -340,7 +338,7 @@ module Make (NM : RPC.S) = struct
       : float =
       let data = struct_storage.NM.StructStorage.data in
       let numeric = NM.Slice.get_int64 data byte_ofs in
-      let bits = Int64.bit_xor numeric default_bits in
+      let bits = Int64.logxor numeric default_bits in
       Int64.float_of_bits bits
 
 
@@ -404,7 +402,7 @@ module Make (NM : RPC.S) = struct
       : unit =
       let data = struct_storage.NM.StructStorage.data in
       let () = set_opt_discriminant data discr in
-      NM.Slice.set_int32 data byte_ofs (Int32.bit_xor value default)
+      NM.Slice.set_int32 data byte_ofs (Int32.logxor value default)
 
     let set_int64
         ?(discr : Discr.t option)
@@ -415,7 +413,7 @@ module Make (NM : RPC.S) = struct
       : unit =
       let data = struct_storage.NM.StructStorage.data in
       let () = set_opt_discriminant data discr in
-      NM.Slice.set_int64 data byte_ofs (Int64.bit_xor value default)
+      NM.Slice.set_int64 data byte_ofs (Int64.logxor value default)
 
     let set_uint8
         ?(discr : Discr.t option)
@@ -471,7 +469,7 @@ module Make (NM : RPC.S) = struct
       let data = struct_storage.NM.StructStorage.data in
       let () = set_opt_discriminant data discr in
       NM.Slice.set_int32 data byte_ofs
-        (Int32.bit_xor (Int32.bits_of_float value) default_bits)
+        (Int32.logxor (Int32.bits_of_float value) default_bits)
 
     let set_float64
         ?(discr : Discr.t option)
@@ -483,7 +481,7 @@ module Make (NM : RPC.S) = struct
       let data = struct_storage.NM.StructStorage.data in
       let () = set_opt_discriminant data discr in
       NM.Slice.set_int64 data byte_ofs
-        (Int64.bit_xor (Int64.bits_of_float value) default_bits)
+        (Int64.logxor (Int64.bits_of_float value) default_bits)
 
 
     (*******************************************************************************

--- a/src/runtime/builderOps.ml
+++ b/src/runtime/builderOps.ml
@@ -30,9 +30,6 @@
 (* Builder operations.  This provides most of the support code required for
    the builder interface. *)
 
-(* Workaround for missing Caml.Bytes in Core 112.35.00 *)
-module CamlBytes = Bytes
-
 type ro = Message.ro
 type rw = Message.rw
 

--- a/src/runtime/bytesStorage.ml
+++ b/src/runtime/bytesStorage.ml
@@ -27,12 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
-(* Workaround for missing Caml.Bytes in Core 112.35.00 *)
-module CamlBytes = Bytes
-
-open Core_kernel.Std
 open EndianBytes
-module Bytes = CamlBytes
 
 type t = Bytes.t
 

--- a/src/runtime/cArray.ml
+++ b/src/runtime/cArray.ml
@@ -169,7 +169,7 @@ let to_list a =
   list_init (length a) ~f:(fun i -> get a i)
 
 let to_array a =
-  Core_kernel.Std.Array.init (length a) ~f:(fun i -> get a i)
+  Array.init (length a) (get a)
 
 let set_list a lst =
   let () = init a (List.length lst) in
@@ -180,7 +180,7 @@ let set_array a arr =
   ArrayLabels.iteri arr ~f:(fun i x -> set a i x)
 
 let map_array a ~f =
-  Core_kernel.Std.Array.init (length a) ~f:(fun i -> f (get a i))
+  Array.init (length a) (fun i -> f (get a i))
 
 let map_list a ~f =
   list_init (length a) ~f:(fun i -> f (get a i))

--- a/src/runtime/cArray.ml
+++ b/src/runtime/cArray.ml
@@ -27,8 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
-open Core_kernel.Std
-
 type ro = Message.ro
 type rw = Message.rw
 
@@ -159,23 +157,23 @@ let find_map a ~f =
   loop 0
 
 let to_list a =
-  List.init (length a) ~f:(fun i -> get a i)
+  Core_kernel.List.init (length a) ~f:(fun i -> get a i)
 
 let to_array a =
   Core_kernel.Std.Array.init (length a) ~f:(fun i -> get a i)
 
 let set_list a lst =
   let () = init a (List.length lst) in
-  List.iteri lst ~f:(fun i x -> set a i x)
+  ListLabels.iteri lst ~f:(fun i x -> set a i x)
 
 let set_array a arr =
   let () = init a (Array.length arr) in
-  Array.iteri arr ~f:(fun i x -> set a i x)
+  ArrayLabels.iteri arr ~f:(fun i x -> set a i x)
 
 let map_array a ~f =
   Core_kernel.Std.Array.init (length a) ~f:(fun i -> f (get a i))
 
 let map_list a ~f =
-  List.init (length a) ~f:(fun i -> f (get a i))
+  Core_kernel.List.init (length a) ~f:(fun i -> f (get a i))
 
 

--- a/src/runtime/cArray.ml
+++ b/src/runtime/cArray.ml
@@ -156,8 +156,17 @@ let find_map a ~f =
   in
   loop 0
 
+let list_init len ~f =
+  let rec aux acc = function
+    | 0 -> acc
+    | i ->
+      let i = i - 1 in
+      aux (f i :: acc) i
+  in
+  aux [] len
+
 let to_list a =
-  Core_kernel.List.init (length a) ~f:(fun i -> get a i)
+  list_init (length a) ~f:(fun i -> get a i)
 
 let to_array a =
   Core_kernel.Std.Array.init (length a) ~f:(fun i -> get a i)
@@ -174,6 +183,4 @@ let map_array a ~f =
   Core_kernel.Std.Array.init (length a) ~f:(fun i -> f (get a i))
 
 let map_list a ~f =
-  Core_kernel.List.init (length a) ~f:(fun i -> f (get a i))
-
-
+  list_init (length a) ~f:(fun i -> f (get a i))

--- a/src/runtime/capnp.ml
+++ b/src/runtime/capnp.ml
@@ -33,7 +33,6 @@ module Array        = CArray
 module BytesStorage = BytesStorage
 module BytesMessage = Message.BytesMessage
 module Codecs       = Codecs
-module IO           = IO
 module RPC          = RPC
 module Runtime = struct
   module BuilderInc      = BuilderInc

--- a/src/runtime/codecs.ml
+++ b/src/runtime/codecs.ml
@@ -28,9 +28,6 @@
  ******************************************************************************)
 
 
-module Result = Core_kernel.Result
-
-
 type compression_t = [ `None | `Packing ]
 
 module FramingError = struct

--- a/src/runtime/codecs.mli
+++ b/src/runtime/codecs.mli
@@ -69,7 +69,7 @@ module FramedStream : sig
       A successful decode removes the data from the stream and returns the
       frame data in the form of a BytesMessage. *)
   val get_next_frame : t ->
-    (Message.rw Message.BytesMessage.Message.t, FramingError.t) Core_kernel.Std.Result.t
+    (Message.rw Message.BytesMessage.Message.t, FramingError.t) Result.result
 end
 
 

--- a/src/runtime/codecsSig.ml
+++ b/src/runtime/codecsSig.ml
@@ -64,6 +64,6 @@ module type DECODER = sig
       frame as a [string list] with one list element for every segment within
       the message. *)
   val get_next_frame : t ->
-    (Message.rw Message.BytesMessage.Message.t, FramingError.t) Core_kernel.Std.Result.t
+    (Message.rw Message.BytesMessage.Message.t, FramingError.t) Result.result
 end
 

--- a/src/runtime/commonInc.ml
+++ b/src/runtime/commonInc.ml
@@ -29,10 +29,6 @@
 
 (* Runtime support which is common to both Reader and Builder interfaces. *)
 
-module CamlBytes = Bytes
-
-open Core_kernel.Std
-
 let sizeof_uint32 = 4
 let sizeof_uint64 = 8
 
@@ -914,12 +910,12 @@ module Make (MessageWrapper : MessageSig.S) = struct
           else
             list_storage.num_elements
         in
-        let buf = CamlBytes.create result_byte_count in
+        let buf = Bytes.create result_byte_count in
         Slice.blit_to_bytes
           ~src:list_storage.storage ~src_pos:0
           ~dst:buf ~dst_pos:0
           ~len:result_byte_count;
-        CamlBytes.unsafe_to_string buf
+        Bytes.unsafe_to_string buf
     | _ ->
         invalid_msg "decoded non-UInt8 list where string data was expected"
 

--- a/src/runtime/commonInc.ml
+++ b/src/runtime/commonInc.ml
@@ -80,7 +80,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
     if Util.is_int64_zero pointer64 then
       Pointer.Null
     else
-      let pointer_int = Caml.Int64.to_int pointer64 in
+      let pointer_int = Int64.to_int pointer64 in
       let tag = pointer_int land Pointer.Bitfield.tag_mask in
       (* OCaml won't match an int against let-bound variables,
          only against constants. *)
@@ -178,7 +178,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
             invalid_msg "composite list pointer describes invalid tag region"
           else
             let pointer64 = Segment.get_int64 segment segment_offset in
-            let pointer_int = Caml.Int64.to_int pointer64 in
+            let pointer_int = Int64.to_int pointer64 in
             let tag = pointer_int land Pointer.Bitfield.tag_mask in
             if tag = Pointer.Bitfield.tag_val_struct then
               let struct_pointer = StructPointer.decode pointer64 in
@@ -274,7 +274,7 @@ module Make (MessageWrapper : MessageSig.S) = struct
       Object.None
     else
       let pointer64 = Slice.get_int64 pointer_bytes 0 in
-      let tag_bits = Caml.Int64.to_int pointer64 in
+      let tag_bits = Int64.to_int pointer64 in
       let tag = tag_bits land Pointer.Bitfield.tag_mask in
       (* OCaml won't match an int against let-bound variables,
          only against constants. *)

--- a/src/runtime/farPointer.ml
+++ b/src/runtime/farPointer.ml
@@ -28,8 +28,6 @@
  ******************************************************************************)
 
 
-module Caml  = Core_kernel.Caml
-
 type landing_pad_t =
   | NormalPointer
   | TaggedFarPointer
@@ -66,9 +64,9 @@ let decode (pointer64 : Int64.t) : t =
   if Sys.word_size = 64 then
     let segment_id =
       let id64 = Int64.shift_right_logical pointer64 segment_shift in
-      Caml.Int64.to_int id64
+      Int64.to_int id64
     in
-    let pointer = Caml.Int64.to_int pointer64 in
+    let pointer = Int64.to_int pointer64 in
     let landing_pad =
       if (pointer land landing_pad_type_mask_int) = 0 then
         NormalPointer
@@ -90,7 +88,7 @@ let decode (pointer64 : Int64.t) : t =
       if Int64.compare id64 max64 > 0 then
         Message.invalid_msg "far pointer contains segment ID larger than OCaml max_int"
       else
-        Caml.Int64.to_int id64
+        Int64.to_int id64
     in
     let landing_pad =
       let masked = Int64.logand pointer64 landing_pad_type_mask in
@@ -102,7 +100,7 @@ let decode (pointer64 : Int64.t) : t =
     let offset =
       let masked = Int64.logand pointer64 offset_mask in
       let offset64 = Int64.shift_right_logical masked offset_shift in
-      Caml.Int64.to_int offset64
+      Int64.to_int offset64
     in {
       landing_pad;
       offset;

--- a/src/runtime/fragmentBuffer.ml
+++ b/src/runtime/fragmentBuffer.ml
@@ -27,11 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
-(* Workaround for missing Caml.Bytes in Core 112.35.00 *)
-module CamlBytes = Bytes
 
-open Core_kernel.Std
-module Bytes = CamlBytes
+module Deque = Core_kernel.Deque
 
 
 type t = {

--- a/src/runtime/fragmentBuffer.ml
+++ b/src/runtime/fragmentBuffer.ml
@@ -28,29 +28,59 @@
  ******************************************************************************)
 
 
-module Deque = Core_kernel.Deque
-
+type fragment = {
+  data : string;
+  mutable next : fragment option;
+}
 
 type t = {
   (** String fragments stored in FIFO order *)
-  fragments : string Deque.t;
+  mutable ends : (fragment * fragment) option;     (* Front, back *)
 
   (** Total byte count of the fragments *)
   mutable fragments_size : int;
 }
 
 let empty () = {
-  fragments = Deque.create ();
+  ends = None;
   fragments_size = 0;
 }
 
-let add_fragment stream fragment =
-  let len = String.length fragment in
-  if len = 0 then
-    ()
-  else
-    let () = Deque.enqueue_back stream.fragments fragment in
+let add_fragment stream data =
+  let len = String.length data in
+  if len > 0 then (
+    let fragment = { data; next = None } in
+    begin match stream.ends with
+      | Some (old_front, old_back) ->
+        old_back.next <- Some fragment;
+        stream.ends <- Some (old_front, fragment)
+      | None ->
+        stream.ends <- Some (fragment, fragment)
+    end;
     stream.fragments_size <- stream.fragments_size + len
+  )
+
+let enqueue_front stream data =
+  match stream.ends with
+  | None ->
+    let fragment = { data; next = None } in
+    stream.ends <- Some (fragment, fragment)
+  | Some (old_front, old_back) ->
+    let fragment = { data; next = Some old_front } in
+    stream.ends <- Some (fragment, old_back)
+
+(* Note: does not update [fragments_size] *)
+let pop stream =
+  match stream.ends with
+  | None ->
+    assert (stream.fragments_size = 0);
+    assert false
+  | Some (fragment, old_back) ->
+    begin match fragment.next with
+    | None -> stream.ends <- None
+    | Some new_front -> stream.ends <- Some (new_front, old_back)
+    end;
+    fragment.data
 
 let of_string s =
   let stream = empty () in
@@ -68,7 +98,7 @@ let remove_exact stream size =
       let ofs = ref 0 in
       while !ofs < size do
         let bytes_remaining = size - !ofs in
-        let fragment = Deque.dequeue_front_exn stream.fragments in
+        let fragment = pop stream in
         let bytes_from_fragment = min bytes_remaining (String.length fragment) in
         Bytes.blit
           (Bytes.unsafe_of_string fragment) 0
@@ -76,7 +106,7 @@ let remove_exact stream size =
           bytes_from_fragment;
         begin if bytes_from_fragment < String.length fragment then
           let remainder = Util.str_slice ~start:bytes_from_fragment fragment in
-          Deque.enqueue_front stream.fragments remainder
+          enqueue_front stream remainder
         end;
         ofs := !ofs + bytes_from_fragment;
       done;
@@ -90,27 +120,22 @@ let remove_at_least stream size =
   else begin
     let buffer = Buffer.create size in
     while Buffer.length buffer < size do
-      Buffer.add_string buffer (Deque.dequeue_front_exn stream.fragments)
+      Buffer.add_string buffer (pop stream)
     done;
     stream.fragments_size <- stream.fragments_size - (Buffer.length buffer);
     Some (Buffer.contents buffer)
   end
 
+let unremove stream data =
+  let len = String.length data in
+  if len > 0 then (
+    enqueue_front stream data;
+    stream.fragments_size <- stream.fragments_size + len;
+  )
+
 let peek_exact stream size =
   match remove_exact stream size with
   | Some bytes ->
-      let () = Deque.enqueue_front stream.fragments bytes in
-      let () = stream.fragments_size <- stream.fragments_size + size in
-      Some bytes
-  | None ->
-      None
-
-let unremove stream bytes =
-  let len = String.length bytes in
-  if len = 0 then
-    ()
-  else
-    let () = Deque.enqueue_front stream.fragments bytes in
-    stream.fragments_size <- stream.fragments_size + len
-
-
+    unremove stream bytes;
+    Some bytes
+  | None -> None

--- a/src/runtime/jbuild
+++ b/src/runtime/jbuild
@@ -8,7 +8,7 @@ let config = {|
   (name capnp)
   (public_name capnp)
   (synopsis "Runtime support library for capnp-ocaml")
-  (libraries (core_kernel uint ocplib-endian res))
+  (libraries (result uint ocplib-endian res))
   (flags (:standard -w -50-53-55))
   (ocamlopt_flags (:standard # -inline 1000))
 ))

--- a/src/runtime/listPointer.ml
+++ b/src/runtime/listPointer.ml
@@ -1,6 +1,4 @@
 
-module Caml  = Core_kernel.Caml
-
 type element_type_t =
   | Void
   | OneBitValue
@@ -43,12 +41,12 @@ let decode (pointer64 : Int64.t) : t =
   let num_elements =
     let shifted64 = Int64.shift_right_logical pointer64 count_shift in
     (* The count is left-aligned in the field, no mask needed *)
-    Caml.Int64.to_int shifted64
+    Int64.to_int shifted64
   in
   (* Int64 arithmetic causes unfortunate GC pressure.  If we're on a 64-bit
      platform, use standard 63-bit ints whenever possible. *)
   if Sys.word_size = 64 then
-    let pointer_int = Caml.Int64.to_int pointer64 in
+    let pointer_int = Int64.to_int pointer64 in
     let offset =
       let v = (pointer_int land offset_mask_int) lsr offset_shift in
       Util.decode_signed 30 v
@@ -74,13 +72,13 @@ let decode (pointer64 : Int64.t) : t =
     let offset =
       let masked     = Int64.logand pointer64 offset_mask in
       let offset64   = Int64.shift_right_logical masked offset_shift in
-      let offset_int = Caml.Int64.to_int offset64 in
+      let offset_int = Int64.to_int offset64 in
       Util.decode_signed 30 offset_int
     in
     let element_type =
       let masked = Int64.logand pointer64 type_mask in
       let tp64   = Int64.shift_right_logical masked type_shift in
-      match Caml.Int64.to_int tp64 with
+      match Int64.to_int tp64 with
       | 0 -> Void
       | 1 -> OneBitValue
       | 2 -> OneByteValue

--- a/src/runtime/message.ml
+++ b/src/runtime/message.ml
@@ -114,7 +114,10 @@ module Make (Storage : MessageStorage.S) = struct
 
     let to_storage m = Res.Array.fold_right (fun x acc -> x :: acc) m.segments []
 
-    let with_message m ~f = Core_kernel.Exn.protectx m ~f ~finally:release
+    let with_message m ~f =
+      match f m with
+      | x -> release m; x
+      | exception ex -> release m; raise ex
 
     let with_attachments attachments m = { m with attachments }
     let get_attachments m = m.attachments

--- a/src/runtime/message.ml
+++ b/src/runtime/message.ml
@@ -28,8 +28,6 @@
  ******************************************************************************)
 
 
-open Core_kernel.Std
-
 type ro = MessageSig.ro
 type rw = MessageSig.rw
 
@@ -110,13 +108,13 @@ module Make (Storage : MessageStorage.S) = struct
 
     let of_storage ms =
       let segments = Res.Array.empty () in
-      let () = List.iter ms ~f:(fun x ->
+      let () = ListLabels.iter ms ~f:(fun x ->
           Res.Array.add_one segments {segment = x; bytes_consumed = Storage.length x}) in
       { segments; attachments = MessageSig.No_attachments }
 
     let to_storage m = Res.Array.fold_right (fun x acc -> x :: acc) m.segments []
 
-    let with_message m ~f = Exn.protectx m ~f ~finally:release
+    let with_message m ~f = Core_kernel.Exn.protectx m ~f ~finally:release
 
     let with_attachments attachments m = { m with attachments }
     let get_attachments m = m.attachments

--- a/src/runtime/otherPointer.ml
+++ b/src/runtime/otherPointer.ml
@@ -28,8 +28,6 @@
  ******************************************************************************)
 
 
-module Caml  = Core_kernel.Caml
-
 type t =
   | Capability of Uint32.t
 
@@ -45,7 +43,7 @@ let decode (pointer64 : Int64.t) : t =
   if Int64.compare (Int64.logand pointer64 b_mask) Int64.zero = 0 then
     let shifted_index = Int64.logand pointer64 index_mask in
     let index64 = Int64.shift_right_logical shifted_index index_shift in
-    let index32 = Caml.Int64.to_int32 index64 in
+    let index32 = Int64.to_int32 index64 in
     Capability (Uint32.of_int32 index32)
   else
     Message.invalid_msg "'other' pointer is of non-capability type"

--- a/src/runtime/readerInc.ml
+++ b/src/runtime/readerInc.ml
@@ -32,8 +32,6 @@
    reading from truncated structs both lead to default data being returned. *)
 
 
-open Core_kernel.Std
-
 let sizeof_uint64 = 8
 
 open Message
@@ -243,7 +241,7 @@ module Make (MessageWrapper : RPC.S) = struct
         let data = struct_storage.StructStorage.data in
         if byte_ofs + 3 < data.Slice.len then
           let numeric = Slice.get_int32 data byte_ofs in
-          Int32.bit_xor numeric default
+          Int32.logxor numeric default
         else
           default
     | None ->
@@ -259,7 +257,7 @@ module Make (MessageWrapper : RPC.S) = struct
         let data = struct_storage.StructStorage.data in
         if byte_ofs + 7 < data.Slice.len then
           let numeric = Slice.get_int64 data byte_ofs in
-          Int64.bit_xor numeric default
+          Int64.logxor numeric default
         else
           default
     | None ->
@@ -345,7 +343,7 @@ module Make (MessageWrapper : RPC.S) = struct
       | None ->
           Int32.zero
     in
-    let bits = Int32.bit_xor numeric default_bits in
+    let bits = Int32.logxor numeric default_bits in
     Int32.float_of_bits bits
 
   let get_float64
@@ -364,7 +362,7 @@ module Make (MessageWrapper : RPC.S) = struct
       | None ->
           Int64.zero
     in
-    let bits = Int64.bit_xor numeric default_bits in
+    let bits = Int64.logxor numeric default_bits in
     Int64.float_of_bits bits
 
 

--- a/src/runtime/readerInc.ml
+++ b/src/runtime/readerInc.ml
@@ -466,7 +466,7 @@ module Make (MessageWrapper : RPC.S) = struct
         if start + len <= pointers.Slice.len then
           (* Fast path. *)
           let pointer64 = Slice.get_int64 pointers start in
-          let pointer_int = Caml.Int64.to_int pointer64 in
+          let pointer_int = Int64.to_int pointer64 in
           let tag = pointer_int land Pointer.Bitfield.tag_mask in
           if tag = Pointer.Bitfield.tag_val_list then
             let list_pointer = ListPointer.decode pointer64 in

--- a/src/runtime/structPointer.ml
+++ b/src/runtime/structPointer.ml
@@ -28,8 +28,6 @@
  ******************************************************************************)
 
 
-module Caml  = Core_kernel.Caml
-
 type t = {
   (** Signed offset in words from end of the pointer to start of struct
       data region. *)
@@ -59,12 +57,12 @@ let decode (pointer64 : Int64.t) : t =
   let pointers_size =
     let shifted64 = Int64.shift_right_logical pointer64 pointers_size_shift in
     (* pointers size is left-aligned, no need to mask it *)
-    Caml.Int64.to_int shifted64
+    Int64.to_int shifted64
   in
   (* Int64 arithmetic causes unfortunate GC pressure.  If we're on a 64-bit
      platform, use standard 63-bit ints whenever possible. *)
   if Sys.word_size = 64 then
-    let pointer = Caml.Int64.to_int pointer64 in
+    let pointer = Int64.to_int pointer64 in
     let offset =
       let v = (pointer land offset_mask_int) lsr offset_shift in
       Util.decode_signed 30 v
@@ -80,13 +78,13 @@ let decode (pointer64 : Int64.t) : t =
     let offset =
       let masked     = Int64.logand pointer64 offset_mask in
       let offset64   = Int64.shift_right_logical masked offset_shift in
-      let offset_int = Caml.Int64.to_int offset64 in
+      let offset_int = Int64.to_int offset64 in
       Util.decode_signed 30 offset_int
     in
     let data_size =
       let masked = Int64.logand pointer64 data_size_mask in
       let size64 = Int64.shift_right_logical masked data_size_shift in
-      Caml.Int64.to_int size64
+      Int64.to_int size64
     in {
       offset;
       data_words    = data_size;

--- a/src/runtime/util.ml
+++ b/src/runtime/util.ml
@@ -31,11 +31,12 @@
 exception Out_of_int_range of string
 let out_of_int_range s = raise (Out_of_int_range s)
 
+let int_size = Sys.word_size - 1        (* For OCaml < 4.03 *)
 
 (* Decode [num] as a signed integer of width [n] bits, using two's complement
    representation of negative numbers. *)
 let decode_signed n num =
-  let () = assert (n < Sys.int_size) in
+  let () = assert (n < int_size) in
   let power_of_two = 1 lsl (n - 1) in
   let is_signed = (num land power_of_two) <> 0 in
   if is_signed then
@@ -47,7 +48,7 @@ let decode_signed n num =
 (* Encode signed integer [num] into [n] bits, using two's complement
    representation of negative numbers. *)
 let encode_signed n num =
-  let () = assert (n < Sys.int_size) in
+  let () = assert (n < int_size) in
   if num >= 0 then
     num
   else

--- a/src/runtime/util.ml
+++ b/src/runtime/util.ml
@@ -27,11 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
-(* Workaround for missing Caml.Bytes in Core 112.35.00 *)
-module CamlBytes = Bytes
-
-open Core_kernel.Std
-module Bytes = CamlBytes
 
 exception Out_of_int_range of string
 let out_of_int_range s = raise (Out_of_int_range s)
@@ -40,7 +35,7 @@ let out_of_int_range s = raise (Out_of_int_range s)
 (* Decode [num] as a signed integer of width [n] bits, using two's complement
    representation of negative numbers. *)
 let decode_signed n num =
-  let () = assert (n < Int.num_bits) in
+  let () = assert (n < Sys.int_size) in
   let power_of_two = 1 lsl (n - 1) in
   let is_signed = (num land power_of_two) <> 0 in
   if is_signed then
@@ -52,7 +47,7 @@ let decode_signed n num =
 (* Encode signed integer [num] into [n] bits, using two's complement
    representation of negative numbers. *)
 let encode_signed n num =
-  let () = assert (n < Int.num_bits) in
+  let () = assert (n < Sys.int_size) in
   if num >= 0 then
     num
   else
@@ -91,35 +86,35 @@ let str_slice ?(start : int option) ?(stop : int option) (s : string)
     | Some x -> norm s x
     | None   -> String.length s
   in
-  String.sub s ~pos:real_start ~len:(real_stop - real_start)
+  Core_kernel.Std.String.sub s ~pos:real_start ~len:(real_stop - real_start)
 
 
 let int_of_int32_exn : int32 -> int =
   if Sys.word_size = 32 then
-    let max_val = Int32.of_int_exn Int.max_value in
-    let min_val = Int32.of_int_exn Int.min_value in
+    let max_val = Int32.of_int max_int in
+    let min_val = Int32.of_int min_int in
     (fun i32 ->
        if Int32.compare i32 min_val < 0 ||
           Int32.compare i32 max_val > 0 then
          out_of_int_range "Int32"
        else
-         Caml.Int32.to_int i32)
+         Int32.to_int i32)
   else
-    Caml.Int32.to_int
+    Int32.to_int
 
 let int_of_int64_exn : int64 -> int =
-  let max_val = Int64.of_int_exn Int.max_value in
-  let min_val = Int64.of_int_exn Int.min_value in
+  let max_val = Int64.of_int max_int in
+  let min_val = Int64.of_int min_int in
   (fun i64 ->
      if Int64.compare i64 min_val < 0 ||
         Int64.compare i64 max_val > 0 then
        out_of_int_range "Int64"
      else
-       Caml.Int64.to_int i64)
+       Int64.to_int i64)
 
 let int_of_uint32_exn : Uint32.t -> int =
   if Sys.word_size = 32 then
-    let max_val = Uint32.of_int Int.max_value in
+    let max_val = Uint32.of_int max_int in
     (fun u32 ->
        if Uint32.compare u32 max_val > 0 then
          out_of_int_range "UInt32"
@@ -129,7 +124,7 @@ let int_of_uint32_exn : Uint32.t -> int =
     Uint32.to_int
 
 let int_of_uint64_exn : Uint64.t -> int =
-  let max_val = Uint64.of_int Int.max_value in
+  let max_val = Uint64.of_int max_int in
   (fun u64 ->
      if Uint64.compare u64 max_val > 0 then
        out_of_int_range "UInt64"
@@ -138,15 +133,15 @@ let int_of_uint64_exn : Uint64.t -> int =
 
 let int32_of_int_exn : int -> int32 =
   if Sys.word_size = 64 then
-    let max_val = Int32.to_int_exn (Int32.max_value) in
-    let min_val = Int32.to_int_exn (Int32.min_value) in
+    let max_val = Int32.to_int Int32.max_int in
+    let min_val = Int32.to_int Int32.min_int in
     (fun i ->
        if i < min_val || i > max_val then
          invalid_arg "Int32.of_int"
        else
-         Caml.Int32.of_int i)
+         Int32.of_int i)
   else
-    Caml.Int32.of_int
+    Int32.of_int
 
 let uint32_of_int_exn : int -> Uint32.t =
   if Sys.word_size = 64 then
@@ -176,7 +171,7 @@ let hex_table = [|
 let make_hex_literal s =
   let result = Bytes.create ((String.length s) * 4) in
   for i = 0 to String.length s - 1 do
-    let byte = Char.to_int s.[i] in
+    let byte = Char.code s.[i] in
     let upper_nibble = (byte lsr 4) land 0xf in
     let lower_nibble = byte land 0xf in
     Bytes.set result ((4 * i) + 0) '\\';
@@ -188,7 +183,7 @@ let make_hex_literal s =
 
 
 let is_int64_zero i64 =
-  (Caml.Int64.float_of_bits i64) = 0.0
+  (Int64.float_of_bits i64) = 0.0
 
 
 (* There are some cases where we can generate tighter assembly
@@ -202,7 +197,7 @@ let int_of_bool (x : bool) : int = Obj.magic x
    integer representation (which interacts poorly with bit shifts).
    It turns out to be more efficient to do table lookups. *)
 
-let get_bit_lookup = Array.create ~len:(256 * 8) false
+let get_bit_lookup = Array.make (256 * 8) false
 let () =
   for byte = 0 to 0xff do
     for bit = 0 to 7 do

--- a/src/runtime/util.ml
+++ b/src/runtime/util.ml
@@ -195,7 +195,6 @@ let is_int64_zero i64 =
    by directly representing a boolean as an integer.  The only
    way to do this in pure OCaml is to use a conditional. *)
 let int_of_bool (x : bool) : int = Obj.magic x
-let bool_of_int (x : int) : bool = Obj.magic x
 
 
 (* The standard bit twiddling logic for "give me bit N of this byte"

--- a/src/runtime/util.ml
+++ b/src/runtime/util.ml
@@ -73,8 +73,9 @@ let round_up_mult_8 (x : int) : int =
    This variant parallels the behavior of Python's slicing operator. *)
 let str_slice ?(start : int option) ?(stop : int option) (s : string)
   : string =
-  let norm s i = Core_kernel.Ordered_collection_common.normalize
-      ~length_fun:String.length s i
+  let norm s i =
+    let len = String.length s in
+    if i >= 0 then i else len + i
   in
   let real_start =
     match start with
@@ -86,7 +87,7 @@ let str_slice ?(start : int option) ?(stop : int option) (s : string)
     | Some x -> norm s x
     | None   -> String.length s
   in
-  Core_kernel.Std.String.sub s ~pos:real_start ~len:(real_stop - real_start)
+  StringLabels.sub s ~pos:real_start ~len:(real_stop - real_start)
 
 
 let int_of_int32_exn : int32 -> int =

--- a/src/tests/jbuild
+++ b/src/tests/jbuild
@@ -2,7 +2,7 @@
 
 (executable
  ((name run_tests)
-  (libraries (capnp oUnit))
+  (libraries (capnp oUnit core_kernel))
   (flags (:standard -w -53))
 ))
 

--- a/src/unix/iO.ml
+++ b/src/unix/iO.ml
@@ -30,6 +30,7 @@
 (* Workaround for missing Caml.Bytes in Core 112.35.00 *)
 module CamlBytes = Bytes
 
+open Capnp
 open Core_kernel.Std
 module Bytes = CamlBytes
 

--- a/src/unix/iO.ml
+++ b/src/unix/iO.ml
@@ -30,7 +30,6 @@
 open Capnp
 
 module Deque = Core_kernel.Deque
-module Result = Core_kernel.Result
 
 type compression_t = [ `None | `Packing ]
 

--- a/src/unix/iO.mli
+++ b/src/unix/iO.mli
@@ -27,6 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
+open Capnp
 
 exception Unsupported_message_frame
 

--- a/src/unix/jbuild
+++ b/src/unix/jbuild
@@ -8,7 +8,7 @@ let config = {|
   (name capnp_unix)
   (public_name capnp.unix)
   (synopsis "Runtime support library for capnp-ocaml (Unix)")
-  (libraries (capnp extunix))
+  (libraries (capnp extunix core_kernel))
   (flags (:standard -w -50-53-55))
   (ocamlopt_flags (:standard # -inline 1000))
 ))

--- a/src/unix/jbuild
+++ b/src/unix/jbuild
@@ -5,10 +5,10 @@ let config = {|
 (jbuild_version 1)
 
 (library (
-  (name capnp)
-  (public_name capnp)
-  (synopsis "Runtime support library for capnp-ocaml")
-  (libraries (core_kernel uint ocplib-endian res))
+  (name capnp_unix)
+  (public_name capnp.unix)
+  (synopsis "Runtime support library for capnp-ocaml (Unix)")
+  (libraries (capnp extunix))
   (flags (:standard -w -50-53-55))
   (ocamlopt_flags (:standard # -inline 1000))
 ))


### PR DESCRIPTION
This PR removes the dependency on `Core_kernel` from the `capnp` library (runtime).

- The main problem was the `Deque` module. However, we didn't use most of its features, so I wrote a short replacement. It makes me a bit nervous, but the module seems to have good tests.

- There is also a simple reimplementation of `List.init`.

The other uses of `Core_kernel` had direct equivalents in the standard library.

I also moved the `Capnp.IO` module to `Capnp_unix.IO`, as unikernels can't depend on `Unix`.

However, we may need to patch the `uint` library too (or switch to a different one; see #9).

/cc @hannesm