### PR TITLE
Fix API changes in Base and Core_kernel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,5 @@ env:
   - OPAMERRLOGLEN=0
   - PACKAGE=capnp
   matrix:
-  - DISTRO=debian-9 OCAML_VERSION=4.02.3
-  - DISTRO=debian-9 OCAML_VERSION=4.03.0
-  - DISTRO=debian-9 OCAML_VERSION=4.04.0
+  - DISTRO=debian-9 OCAML_VERSION=4.04.2
   - DISTRO=debian-9 OCAML_VERSION=4.05.0

--- a/capnp.opam
+++ b/capnp.opam
@@ -12,7 +12,7 @@ build-test: ["jbuilder" "build" "@runtest" "@src/benchmark/benchmarks"]
 depends: [
   "jbuilder" {build}
   "result"
-  "core_kernel" {>= "112.24.00"}
+  "core_kernel" {>= "v0.10.0"}
   "extunix"
   "ocplib-endian" {>= "0.7"}
   "res"

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -53,7 +53,7 @@ let main () : int =
           let () = Generate.compile request in
           ExitCode.success
         with (Failure _) as e ->
-          let bs = Exn.backtrace () in
+          let bs = Printexc.get_backtrace () in
           let es = Exn.to_string e in
           let () = prerr_endline es in
           let () = prerr_endline bs in

--- a/src/tests/testCodecs.ml
+++ b/src/tests/testCodecs.ml
@@ -183,7 +183,8 @@ let random_packing_suite =
 let message_gen =
   let open Quickcheck.Generator.Monad_infix in
   let segment_gen = capnp_string_gen >>| Bytes.unsafe_of_string in
-  List.gen' ~length:(`Between_inclusive (1, 25)) segment_gen
+  Int.gen_uniform_incl 1 25 >>= fun length ->
+  List.gen_with_length length segment_gen
   >>| Capnp.BytesMessage.Message.of_storage
 
 let test_random_serialize_deserialize _ctx =


### PR DESCRIPTION
- It appears that `Exn.backtrace` was removed from base in v0.9.114.39. The commit does not say why.

- `List.gen'` has been replaced by `List.gen_with_length`.