### PR TITLE
Depend on conf-capnproto for capnproto compiler

### DIFF
--- a/capnp.opam
+++ b/capnp.opam
@@ -19,12 +19,6 @@ depends: [
   "uint"
   "core" {test}
   "ounit" {test}
-]
-depexts: [
-  [["debian"] ["capnproto" "libcapnp-dev"]]
-  [["ubuntu"] ["capnproto" "libcapnp-dev"]]
-  [["fedora"] ["capnproto"]]
-  [["centos"] ["capnproto"]]
-  [["osx"] ["capnp"]]
+  "conf-capnproto" {test}
 ]
 available: [ ocaml-version >= "4.02.0" ]


### PR DESCRIPTION
Also, it is now a test dependency. This allows capnp to be used on platforms without the compiler, but it does mean that packages that compile schema files will need to add their own dependency on the C++ compiler.