### PR TITLE
Remove core kernel

### DIFF
--- a/capnp.opam
+++ b/capnp.opam
@@ -8,7 +8,9 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0"}
   "result"
-  "core_kernel" {>= "v0.11.0"}
+  "base"
+  "stdio"
+  "core_kernel" {with-test & >= "v0.11.0"}
   "extunix"
   "ocplib-endian" {>= "0.7"}
   "res"

--- a/src/benchmark/dune
+++ b/src/benchmark/dune
@@ -1,6 +1,6 @@
 (executable
  (name main)
- (libraries capnp capnp_unix fast_rand)
+ (libraries capnp capnp_unix fast_rand core_kernel)
  (flags :standard -w -53-55)
  (ocamlopt_flags :standard -O3 -inline 2000))
 

--- a/src/compiler/defaults.ml
+++ b/src/compiler/defaults.ml
@@ -55,7 +55,9 @@
 (* Workaround for missing Caml.Bytes in Core 112.35.00 *)
 module CamlBytes = Bytes
 
-open Core_kernel
+module String = Base.String
+module List = Base.List
+module Int = Base.Int
 
 module Copier = Capnp.Runtime.BuilderOps.Make(GenCommon.M)(GenCommon.M)
 module M = GenCommon.M

--- a/src/compiler/genCommon.ml
+++ b/src/compiler/genCommon.ml
@@ -28,7 +28,10 @@
  ******************************************************************************)
 
 
-open Core_kernel
+module String = Base.String
+module List = Base.List
+module Char = Base.Char
+module Hashtbl = Base.Hashtbl
 
 module M   = Capnp.RPC.None(Capnp.BytesMessage)
 module PS_ = PluginSchema.Make(M)

--- a/src/compiler/genModules.ml
+++ b/src/compiler/genModules.ml
@@ -30,7 +30,8 @@
 (* Workaround for missing Caml.Bytes in Core 112.35.00 *)
 module CamlBytes = Bytes
 
-open Core_kernel
+module Int = Base.Int
+module List = Base.List
 
 module PS        = GenCommon.PS
 module Context   = GenCommon.Context
@@ -1199,7 +1200,7 @@ let generate_union_getter ~context ~scope ~mode struct_def fields =
       let cases = List.fold_left fields ~init:[] ~f:(fun acc field ->
         let field_name = PS.Field.name_get field in
         let us_field_name = GenCommon.underscore_name field_name in
-        let ctor_name = String.capitalize field_name in
+        let ctor_name = String.capitalize_ascii field_name in
         let field_value = PS.Field.discriminant_value_get field in
         let field_has_void_type =
           match PS.Field.get field with
@@ -1361,12 +1362,12 @@ let generate_constant ~context ~scope ~node ~node_name const_def =
         GenCommon.get_scope_relative_name ~context scope enum_node in
       if enum_val >= C.Array.length enumerants then
         [ sprintf "%s.%s %u" scope_relative_name
-            (String.capitalize undefined_name) enum_val ]
+            (String.capitalize_ascii undefined_name) enum_val ]
       else
         let enumerant = C.Array.get enumerants enum_val in
         [ sprintf "%s.%s"
             scope_relative_name
-            (String.capitalize (PS.Enumerant.name_get enumerant)) ]
+            (String.capitalize_ascii (PS.Enumerant.name_get enumerant)) ]
   | (Type.Struct _, Value.Struct _) ->
       let node_id = PS.Node.id_get node in
       let name = GenCommon.underscore_name node_name in
@@ -1492,7 +1493,7 @@ and generate_methods ~context ~scope ~nested_modules ~mode ~interface_node inter
   in
   let structs =
     List.map methods ~f:(fun m ->
-        let mod_name = String.capitalize (Method.capnp_name m) in
+        let mod_name = String.capitalize_ascii (Method.capnp_name m) in
         ["module " ^ mod_name ^ " = struct"] @
         apply_indent ~indent:"  " (
             make_auto m Method.Params @
@@ -1742,7 +1743,7 @@ let generate_client ~context ~nested_modules ~node_name ~interface_node interfac
     List.map methods ~f:(fun m ->
         let params = Method.(payload_module Params) ~context ~mode:Mode.Builder m in
         let results = Method.(payload_module Results) ~context ~mode:Mode.Reader m in
-        let mod_name = String.capitalize (Method.capnp_name m) in
+        let mod_name = String.capitalize_ascii (Method.capnp_name m) in
         ["module " ^ mod_name ^ " = struct"] @
         apply_indent ~indent:"  " [
           "module Params = " ^ params;
@@ -1779,7 +1780,7 @@ let generate_service ~context ~nested_modules ~node_name ~interface_node interfa
     List.map methods ~f:(fun m ->
         let params = Method.(payload_module Params) ~context ~mode:Mode.Reader m in
         let results = Method.(payload_module Results) ~context ~mode:Mode.Builder m in
-        let mod_name = String.capitalize (Method.capnp_name m) in
+        let mod_name = String.capitalize_ascii (Method.capnp_name m) in
         ["module " ^ mod_name ^ " = struct"] @
         apply_indent ~indent:"  " [
           "module Params = " ^ params;
@@ -1792,7 +1793,7 @@ let generate_service ~context ~nested_modules ~node_name ~interface_node interfa
   let service =
     let body =
       List.map methods ~f:(fun m ->
-          let meth_mod_name = String.capitalize (Method.capnp_name m) in
+          let meth_mod_name = String.capitalize_ascii (Method.capnp_name m) in
           sprintf "method virtual %s_impl : (%s.Params.t, %s.Results.t) MessageWrapper.Service.method_t"
             (Method.ocaml_name m)
             meth_mod_name

--- a/src/compiler/genSignatures.ml
+++ b/src/compiler/genSignatures.ml
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
-
-open Core_kernel
+module List = Base.List
+module Int = Base.Int
 
 module PS      = GenCommon.PS
 module Context = GenCommon.Context
@@ -380,7 +380,7 @@ let generate_method_struct ~context ~scope ~nested_modules ~mode ~interface_node
   in
   let structs =
     List.map methods ~f:(fun m ->
-        let mod_name = String.capitalize (Method.capnp_name m) in
+        let mod_name = String.capitalize_ascii (Method.capnp_name m) in
         ["module " ^ mod_name ^ " : sig"] @
         apply_indent ~indent:"  " (
             make_auto m Method.Params @
@@ -400,7 +400,7 @@ let generate_client ~context ~nested_modules ~interface_node interface_def : str
     List.map methods ~f:(fun m ->
         let params = Method.(payload_module Params) ~context ~mode:Mode.Builder m in
         let results = Method.(payload_module Results) ~context ~mode:Mode.Reader m in
-        let mod_name = String.capitalize (Method.capnp_name m) in
+        let mod_name = String.capitalize_ascii (Method.capnp_name m) in
         ["module " ^ mod_name ^ " : sig"] @
         apply_indent ~indent:"  " [
           "module Params = " ^ params;
@@ -421,7 +421,7 @@ let generate_service ~context ~nested_modules ~interface_node interface_def : st
     List.map methods ~f:(fun m ->
         let params = Method.(payload_module Params) ~context ~mode:Mode.Reader m in
         let results = Method.(payload_module Results) ~context ~mode:Mode.Builder m in
-        let mod_name = String.capitalize (Method.capnp_name m) in
+        let mod_name = String.capitalize_ascii (Method.capnp_name m) in
         ["module " ^ mod_name ^ " : sig"] @
         apply_indent ~indent:"  " [
           "module Params = " ^ params;
@@ -434,7 +434,7 @@ let generate_service ~context ~nested_modules ~interface_node interface_def : st
   let server =
     let body =
       List.map methods ~f:(fun m ->
-          let meth_mod_name = String.capitalize (Method.capnp_name m) in
+          let meth_mod_name = String.capitalize_ascii (Method.capnp_name m) in
           sprintf "method virtual %s_impl : (%s.Params.t, %s.Results.t) MessageWrapper.Service.method_t"
             (Method.ocaml_name m)
             meth_mod_name
@@ -491,7 +491,7 @@ let rec generate_node
           [ "end" ]
   | Enum enum_def ->
       let unique_module_name =
-        (String.capitalize node_name) ^ "_" ^ (Uint64.to_string node_id)
+        (String.capitalize_ascii node_name) ^ "_" ^ (Uint64.to_string node_id)
       in
       let body =
         (generate_nested_modules ()) @

--- a/src/compiler/generate.ml
+++ b/src/compiler/generate.ml
@@ -27,8 +27,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
-
-open Core_kernel
+module List = Base.List
+module String = Base.String
+module Hashtbl = Base.Hashtbl
+module Out_channel = Stdio.Out_channel
 
 module PS   = GenCommon.PS
 module C    = Capnp

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -27,8 +27,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
+module Exn = Base.Exn
+module In_channel = Stdio.In_channel
 
-open Core_kernel
 open Capnp
 
 module M  = BytesMessage

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -2,6 +2,6 @@
  (name capnp_unix)
  (public_name capnp.unix)
  (synopsis "Runtime support library for capnp-ocaml (Unix)")
- (libraries capnp extunix core_kernel)
+ (libraries capnp extunix base stdio)
  (flags :standard -w -50-53-55)
  (ocamlopt_flags :standard -O3 -inline 1000))


### PR DESCRIPTION
Core_kernel is now only needed for the tests. This greatly reduces the number of libraries you need to install to run the schema compiler. This is on top of #55.