### PR TITLE
Remove extunix and camlp4 dependencies

### DIFF
--- a/capnp.opam
+++ b/capnp.opam
@@ -11,7 +11,6 @@ depends: [
   "base"
   "stdio"
   "core_kernel" {with-test & >= "v0.11.0"}
-  "extunix"
   "ocplib-endian" {>= "0.7"}
   "res"
   "uint"

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -73,5 +73,5 @@ let main () : int =
       ExitCode.general_error
 
 
-let () = Pervasives.exit (main ())
+let () = exit (main ())
 

--- a/src/runtime/cArray.ml
+++ b/src/runtime/cArray.ml
@@ -74,7 +74,7 @@ let mem ?equal a x =
     | Some user_equal ->
         user_equal
     | None ->
-        Pervasives.(=)
+        (=)
   in
   let rec loop i =
     if i = len then

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -2,6 +2,6 @@
  (name capnp_unix)
  (public_name capnp.unix)
  (synopsis "Runtime support library for capnp-ocaml (Unix)")
- (libraries capnp extunix base stdio)
+ (libraries capnp unix base stdio)
  (flags :standard -w -50-53-55)
  (ocamlopt_flags :standard -O3 -inline 1000))

--- a/src/unix/iO.ml
+++ b/src/unix/iO.ml
@@ -204,7 +204,7 @@ let create_read_context_for_fd ?(restart = true) ~compression fd =
 
 let create_read_context_for_channel ~compression chan =
   let in_chan_read ic ~buf ~pos ~len =
-    Pervasives.input ic buf pos len
+    input ic buf pos len
   in
   ReadContext.create ~read:in_chan_read ~compression chan
 

--- a/src/unix/iO.ml
+++ b/src/unix/iO.ml
@@ -240,37 +240,6 @@ let write_message_to_file ?perm ~compression message filename =
     write_message_to_channel ~compression message oc)
 
 
-let write_message_to_file_robust ?perm ~compression message filename =
-  let parent_dir = Filename.dirname filename in
-  let tmp_prefix = (Filename.basename filename) ^ "-tmp" in
-  let (tmp_filename, tmp_oc) = Filename.open_temp_file
-      ~mode:[Open_binary] ~temp_dir:parent_dir tmp_prefix ""
-  in
-  let () = Base.Exn.protectx tmp_oc ~finally:Stdio.Out_channel.close ~f:(fun oc ->
-      let () = write_message_to_channel ~compression message oc in
-      let () = Stdio.Out_channel.flush oc in
-      let fd = UnixLabels.descr_of_out_channel tmp_oc in
-      ExtUnix.Specific.fsync fd)
-  in
-  let () = UnixLabels.rename ~src:tmp_filename ~dst:filename in
-  let () =
-    (* [open_temp_file] always creates as 0o600, so we may need to touch up permissions *)
-    match perm with
-    | Some perm ->
-        UnixLabels.chmod filename ~perm
-    | None ->
-        ()
-  in
-  (* Attempt to sync directory metadata, so the rename is durably
-     recorded.  May not work as expected on all platforms, so
-     suppress errors. *)
-  try
-    let fd = UnixLabels.openfile parent_dir ~mode:[UnixLabels.O_RDONLY] ~perm:0o600 in
-    Base.Exn.protectx fd ~finally:UnixLabels.close ~f:ExtUnix.Specific.fsync
-  with Unix.Unix_error (_, _, _) ->
-    ()
-
-
 let read_single_message_from_fd ?(restart = true) ~compression fd =
   let context = create_read_context_for_fd ~restart ~compression fd in
   let rec read_loop () =

--- a/src/unix/iO.mli
+++ b/src/unix/iO.mli
@@ -125,7 +125,7 @@ val create_write_context_for_fd : ?restart:bool -> compression:Codecs.compressio
     writing messages to the given buffered output channel using the specified
     [compression] format. *)
 val create_write_context_for_channel : compression:Codecs.compression_t ->
-  Pervasives.out_channel -> Pervasives.out_channel WriteContext.t
+  out_channel -> out_channel WriteContext.t
 
 
 (** [create_read_context_for_fd ~compression fd] creates a context for reading
@@ -140,7 +140,7 @@ val create_read_context_for_fd : ?restart:bool -> compression:Codecs.compression
     reading messages from the given input channel using the specified
     [compression] method. *)
 val create_read_context_for_channel : compression:Codecs.compression_t ->
-  Pervasives.in_channel -> Pervasives.in_channel ReadContext.t
+  in_channel -> in_channel ReadContext.t
 
 
 (** [write_message_to_fd ~compression message fd] writes the specified [message] to
@@ -159,7 +159,7 @@ val write_message_to_fd : ?restart:bool -> compression:Codecs.compression_t ->
     [message] to the given buffered I/O channel, using the specified [compression]
     method. *)
 val write_message_to_channel : compression:Codecs.compression_t ->
-  'cap Message.BytesMessage.Message.t -> Pervasives.out_channel -> unit
+  'cap Message.BytesMessage.Message.t -> out_channel -> unit
 
 
 (** [write_message_to_file ~compression message filename] writes the specified
@@ -208,7 +208,7 @@ val read_single_message_from_fd : ?restart:bool -> compression:Codecs.compressio
     @raise Unsupported_message_frame if the frame header describes a segment
     count or segment size that is too large for the implementation *)
 val read_single_message_from_channel : compression:Codecs.compression_t ->
-  Pervasives.in_channel -> Message.rw Message.BytesMessage.Message.t option
+  in_channel -> Message.rw Message.BytesMessage.Message.t option
 
 
 (** [read_message_from_file ~compression filename] attempts to read a

--- a/src/unix/iO.mli
+++ b/src/unix/iO.mli
@@ -170,18 +170,6 @@ val write_message_to_file : ?perm:int -> compression:Codecs.compression_t ->
   'cap Message.BytesMessage.Message.t -> string -> unit
 
 
-(** As [write_message_to_file], but the file is constructed transactionally
-    by writing to a temporary file and renaming to the [filename], and
-    [Unix.fsync] is used carefully to ensure durability of the write.
-
-    The overhead of [rename] and [fsync] may lead to reduced throughput
-    relative to [write_message_to_file].
-
-    @raise Unix.Unix_error if [write], [fsync], or [rename] operations fail. *)
-val write_message_to_file_robust : ?perm:int -> compression:Codecs.compression_t ->
-  'cap Message.BytesMessage.Message.t -> string -> unit
-
-
 (** [read_single_message_from_fd ~compression fd] attempts to read a single
     message from the specified file descriptor, using the given [compression]
     method.  If [restart] is set to [true] (default), then writes failing


### PR DESCRIPTION
- Remove `extunix` dependency. `write_message_to_file_robust` was the only user of the `extunix` library and doesn't appear to be used by anything. Writing a file atomically seems like a general function that should be provided by an external library.

- Removing `extunix` also removes the indirect dependency on `camlp4`, which in turn allows `capnp` to build with OCaml 4.08 (and to build faster on all versions).

- Remove `Pervasives` qualifier. Since we no longer open any replacement standard libraries, we can refer to the default ones without a prefix. This is needed to support OCaml 4.08, which otherwise fails with:

      Error (alert deprecated): module Stdlib.Pervasives
      Use Stdlib instead.