### PR TITLE
Remove test dependency on Core_kernel

### DIFF
--- a/capnp.opam
+++ b/capnp.opam
@@ -10,7 +10,7 @@ depends: [
   "result"
   "base"
   "stdio"
-  "core_kernel" {with-test & >= "v0.11.0"}
+  "base_quickcheck" {with-test}
   "ocplib-endian" {>= "0.7"}
   "res"
   "uint"

--- a/src/benchmark/capnpCatrank.ml
+++ b/src/benchmark/capnpCatrank.ml
@@ -3,7 +3,9 @@ module CamlBytes = Bytes
 
 module CR = Catrank.Make[@inlined](Capnp.BytesMessage)
 
-open Core_kernel
+module Array = Base.Array
+module Char = Base.Char
+module Float = Base.Float
 
 module TestCase = struct
   type request_t     = CR.Reader.SearchResultList.struct_t

--- a/src/benchmark/capnpEval.ml
+++ b/src/benchmark/capnpEval.ml
@@ -1,7 +1,7 @@
 
 module E = Eval.Make[@inlined](Capnp.BytesMessage)
 
-open Core_kernel
+module Int32 = Base.Int32
 
 module TestCase = struct
   type request_t     = E.Reader.Expression.struct_t

--- a/src/benchmark/dune
+++ b/src/benchmark/dune
@@ -1,6 +1,6 @@
 (executable
  (name main)
- (libraries capnp capnp_unix fast_rand core_kernel)
+ (libraries capnp capnp_unix fast_rand base)
  (flags :standard -w -53-55)
  (ocamlopt_flags :standard -O3 -inline 2000))
 

--- a/src/benchmark/main.ml
+++ b/src/benchmark/main.ml
@@ -1,9 +1,7 @@
-
-open Core_kernel
+module Int = Base.Int
 
 let printf = Printf.printf
 let fprintf = Printf.fprintf
-
 
 module BenchmarkRunner(BM : Methods.BENCHMARK_SIG) = struct
 
@@ -63,7 +61,7 @@ let () =
     if name = "carsales" then
       (* Carsales benefits a small amount from tuning the GC to
          increase the space overhead. *)
-      let () = Gc.tune ~space_overhead:1000 () in
+      let () = Gc.(set {(get ()) with space_overhead = 1000}) in
       let module BM = Methods.Benchmark
           (CapnpCarsales.TestCase)
           (CapnpCarsales.CS.Reader.ParkingLot)
@@ -75,7 +73,7 @@ let () =
       (* Catrank allocates relatively large messages.  It benefits from
          tuning the GC to increase the space overhead and thus reduce
          the major collection rate. *)
-      let () = Gc.tune ~space_overhead:10000 () in
+      let () = Gc.(set {(get ()) with space_overhead = 1000}) in
       let module BM = Methods.Benchmark
           (CapnpCatrank.TestCase)
           (CapnpCatrank.CR.Reader.SearchResultList)

--- a/src/tests/dune
+++ b/src/tests/dune
@@ -1,6 +1,6 @@
 (executable
  (name run_tests)
- (libraries capnp oUnit core_kernel)
+ (libraries capnp oUnit base_quickcheck)
  (flags :standard -w -53))
 
 (rule

--- a/src/tests/testEncoding.ml
+++ b/src/tests/testEncoding.ml
@@ -29,9 +29,10 @@
 
 (* Inspired by encoding-test.c++, as found in the capnproto source. *)
 
-module CamlBytes = Bytes
-open Core_kernel
-module Bytes = CamlBytes
+module Int = Base.Int
+module Int64 = Base.Int64
+module Float = Base.Float
+module List = Base.List
 
 module BM  = Capnp.BytesMessage
 module T   = Test.Make(BM)


### PR DESCRIPTION
Turns out that `Base_quickcheck` can do the same things.