### PR TITLE
Upgrade from uint to stdint

### DIFF
--- a/capnp.opam
+++ b/capnp.opam
@@ -13,7 +13,7 @@ depends: [
   "base_quickcheck" {with-test}
   "ocplib-endian" {>= "0.7"}
   "res"
-  "uint"
+  "stdint"
   "ounit" {with-test}
   "conf-capnproto" {with-test}
 ]

--- a/src/compiler/defaults.ml
+++ b/src/compiler/defaults.ml
@@ -52,6 +52,8 @@
    from string storage into this new message of the correct type.
 *)
 
+module Uint64 = Stdint.Uint64
+
 (* Workaround for missing Caml.Bytes in Core 112.35.00 *)
 module CamlBytes = Bytes
 

--- a/src/compiler/defaults.mli
+++ b/src/compiler/defaults.mli
@@ -33,6 +33,7 @@
    objects into a StringStorage-based message, so we can easily serialize
    the string contents right into the generated code. *)
 
+module Uint64 = Stdint.Uint64
 
 type t
 type ident_t

--- a/src/compiler/genCommon.ml
+++ b/src/compiler/genCommon.ml
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
+module Uint32 = Stdint.Uint32
+module Uint64 = Stdint.Uint64
 
 module String = Base.String
 module List = Base.List
@@ -628,8 +630,8 @@ let rec type_name ~context ~(mode : Mode.t) ~(scope_mode : Mode.t)
   | Int64   -> "int64"
   | Uint8   -> "int"
   | Uint16  -> "int"
-  | Uint32  -> "Uint32.t"
-  | Uint64  -> "Uint64.t"
+  | Uint32  -> "Stdint.Uint32.t"
+  | Uint64  -> "Stdint.Uint64.t"
   | Float32 -> "float"
   | Float64 -> "float"
   | Text    -> "string"

--- a/src/compiler/genModules.ml
+++ b/src/compiler/genModules.ml
@@ -27,6 +27,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
+module Uint32 = Stdint.Uint32
+module Uint64 = Stdint.Uint64
+
 (* Workaround for missing Caml.Bytes in Core 112.35.00 *)
 module CamlBytes = Bytes
 
@@ -872,9 +875,9 @@ let generate_one_field_accessors ~context ~node_id ~scope
         | (PS.Type.Uint32, PS.Value.Uint32 a) ->
             let default =
               if Uint32.compare a Uint32.zero = 0 then
-                "Uint32.zero"
+                "Stdint.Uint32.zero"
               else
-                sprintf "(Uint32.of_string \"%s\")" (Uint32.to_string a)
+                sprintf "(Stdint.Uint32.of_string \"%s\")" (Uint32.to_string a)
             in
             let getters = [
               "let " ^ field_name ^ "_get x =";
@@ -898,9 +901,9 @@ let generate_one_field_accessors ~context ~node_id ~scope
         | (PS.Type.Uint64, PS.Value.Uint64 a) ->
             let default =
               if Uint64.compare a Uint64.zero = 0 then
-                "Uint64.zero"
+                "Stdint.Uint64.zero"
               else
-                sprintf "(Uint64.of_string \"%s\")" (Uint64.to_string a)
+                sprintf "(Stdint.Uint64.of_string \"%s\")" (Uint64.to_string a)
             in
             let getters = [
               "let " ^ field_name ^ "_get x =";
@@ -1326,9 +1329,9 @@ let generate_constant ~context ~scope ~node ~node_name const_def =
   | (Type.Int64, Value.Int64 a) ->
       [ (Int64.to_string a) ^ "L" ]
   | (Type.Uint32, Value.Uint32 a) ->
-      [ sprintf "(Uint32.of_string \"%s\")" (Uint32.to_string a) ]
+      [ sprintf "(Stdint.Uint32.of_string \"%s\")" (Uint32.to_string a) ]
   | (Type.Uint64, Value.Uint64 a) ->
-      [ sprintf "(Uint64.of_string \"%s\")" (Uint64.to_string a) ]
+      [ sprintf "(Stdint.Uint64.of_string \"%s\")" (Uint64.to_string a) ]
   | (Type.Float32, Value.Float32 a) ->
       [ sprintf "(Int32.float_of_bits (%sl))"
           (Int32.to_string (Int32.bits_of_float a)) ]
@@ -1858,7 +1861,7 @@ let rec generate_interfaces fn
       let unique_type = GenCommon.make_unique_typename ~context node in
       let body = [
         "type t = " ^ unique_type;
-        sprintf "let interface_id = Uint64.of_string %S" (Uint64.to_string_hex (PS.Node.id_get node));
+        sprintf "let interface_id = Stdint.Uint64.of_string %S" (Uint64.to_string_hex (PS.Node.id_get node));
       ] @
         fn ~context ~nested_modules ~node_name ~interface_node:node iface_def
       in

--- a/src/compiler/genSignatures.ml
+++ b/src/compiler/genSignatures.ml
@@ -27,6 +27,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
+module Uint32 = Stdint.Uint32
+module Uint64 = Stdint.Uint64
+
 module List = Base.List
 module Int = Base.Int
 
@@ -98,15 +101,15 @@ let generate_one_field_accessors ~context ~scope ~mode field
           Setter [ "val " ^ field_name ^ "_set_int : t -> int -> unit"; ];
         ]
       | Uint32 -> [
-          Getter [ "val " ^ field_name ^ "_get : t -> Uint32.t"; ];
+          Getter [ "val " ^ field_name ^ "_get : t -> Stdint.Uint32.t"; ];
           Getter [ "val " ^ field_name ^ "_get_int_exn : t -> int"; ];
-          Setter [ "val " ^ field_name ^ "_set : t -> Uint32.t -> unit"; ];
+          Setter [ "val " ^ field_name ^ "_set : t -> Stdint.Uint32.t -> unit"; ];
           Setter [ "val " ^ field_name ^ "_set_int_exn : t -> int -> unit"; ]
         ]
       | Uint64 -> [
-          Getter [ "val " ^ field_name ^ "_get : t -> Uint64.t"; ];
+          Getter [ "val " ^ field_name ^ "_get : t -> Stdint.Uint64.t"; ];
           Getter [ "val " ^ field_name ^ "_get_int_exn : t -> int"; ];
-          Setter [ "val " ^ field_name ^ "_set : t -> Uint64.t -> unit"; ];
+          Setter [ "val " ^ field_name ^ "_set : t -> Stdint.Uint64.t -> unit"; ];
           Setter [ "val " ^ field_name ^ "_set_int_exn : t -> int -> unit"; ];
         ]
       | Void -> [
@@ -560,7 +563,7 @@ let rec generate_interfaces fn
       let unique_type = GenCommon.make_unique_typename ~context node in
       let body = [
         "type t = " ^ unique_type;
-        "val interface_id : Uint64.t";
+        "val interface_id : Stdint.Uint64.t";
       ] @ fn ~context ~nested_modules ~interface_node:node iface_def
       in
       if suppress_module_wrapper then

--- a/src/compiler/generate.ml
+++ b/src/compiler/generate.ml
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
+module Uint64 = Stdint.Uint64
+
 module List = Base.List
 module String = Base.String
 module Hashtbl = Base.Hashtbl

--- a/src/compiler/pluginSchema.ml
+++ b/src/compiler/pluginSchema.ml
@@ -1,5 +1,8 @@
 [@@@ocaml.warning "-27-32-37-60"]
 
+module Uint32 = Stdint.Uint32
+module Uint64 = Stdint.Uint64
+
 type ro = Capnp.Message.ro
 type rw = Capnp.Message.rw
 

--- a/src/compiler/pluginSchema.mli
+++ b/src/compiler/pluginSchema.mli
@@ -1,5 +1,8 @@
 [@@@ocaml.warning "-27-32-37-60"]
 
+module Uint32 = Stdint.Uint32
+module Uint64 = Stdint.Uint64
+
 type ro = Capnp.Message.ro
 type rw = Capnp.Message.rw
 

--- a/src/runtime/builderInc.ml
+++ b/src/runtime/builderInc.ml
@@ -34,6 +34,9 @@
    pointer will cause struct storage to be immediately allocated if that pointer
    was null). *)
 
+module Uint32 = Stdint.Uint32
+module Uint64 = Stdint.Uint64
+
 type ro = Message.ro
 type rw = Message.rw
 let invalid_msg = Message.invalid_msg

--- a/src/runtime/bytesStorage.ml
+++ b/src/runtime/bytesStorage.ml
@@ -29,6 +29,9 @@
 
 open EndianBytes
 
+module Uint32 = Stdint.Uint32
+module Uint64 = Stdint.Uint64
+
 type t = Bytes.t
 
 let alloc size = Bytes.make size '\x00'

--- a/src/runtime/dune
+++ b/src/runtime/dune
@@ -2,6 +2,6 @@
  (name capnp)
  (public_name capnp)
  (synopsis "Runtime support library for capnp-ocaml")
- (libraries result uint ocplib-endian res)
+ (libraries result stdint ocplib-endian res)
  (flags :standard -w -50-53-55)
  (ocamlopt_flags :standard -O3 -inline 1000))

--- a/src/runtime/message.ml
+++ b/src/runtime/message.ml
@@ -27,6 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
+module Uint32 = Stdint.Uint32
 
 type ro = MessageSig.ro
 type rw = MessageSig.rw

--- a/src/runtime/messageSig.ml
+++ b/src/runtime/messageSig.ml
@@ -27,6 +27,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
+module Uint32 = Stdint.Uint32
+module Uint64 = Stdint.Uint64
+
 type ro
 type rw
 

--- a/src/runtime/messageStorage.ml
+++ b/src/runtime/messageStorage.ml
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
+module Uint32 = Stdint.Uint32
+module Uint64 = Stdint.Uint64
 
 module type S = sig
   (** [t] is the type of the underlying storage used for message segments. *)

--- a/src/runtime/otherPointer.ml
+++ b/src/runtime/otherPointer.ml
@@ -27,6 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
+module Uint32 = Stdint.Uint32
 
 type t =
   | Capability of Uint32.t

--- a/src/runtime/rPC.ml
+++ b/src/runtime/rPC.ml
@@ -1,3 +1,6 @@
+module Uint32 = Stdint.Uint32
+module Uint64 = Stdint.Uint64
+
 module Registry : sig
   (** Handy central registry of all known interfaces, for logging. *)
 

--- a/src/runtime/readerInc.ml
+++ b/src/runtime/readerInc.ml
@@ -31,6 +31,8 @@
    here will modify the underlying message; derefencing null pointers and
    reading from truncated structs both lead to default data being returned. *)
 
+module Uint32 = Stdint.Uint32
+module Uint64 = Stdint.Uint64
 
 let sizeof_uint64 = 8
 

--- a/src/runtime/util.ml
+++ b/src/runtime/util.ml
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
+module Uint32 = Stdint.Uint32
+module Uint64 = Stdint.Uint64
 
 exception Out_of_int_range of string
 let out_of_int_range s = raise (Out_of_int_range s)

--- a/src/tests/testBytesStorage.ml
+++ b/src/tests/testBytesStorage.ml
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
+module Uint32 = Stdint.Uint32
+module Uint64 = Stdint.Uint64
 
 module SM = Capnp.Message.Make(Capnp.BytesStorage)
 open OUnit2

--- a/src/tests/testEncoding.ml
+++ b/src/tests/testEncoding.ml
@@ -29,6 +29,9 @@
 
 (* Inspired by encoding-test.c++, as found in the capnproto source. *)
 
+module Uint32 = Stdint.Uint32
+module Uint64 = Stdint.Uint64
+
 module Int = Base.Int
 module Int64 = Base.Int64
 module Float = Base.Float


### PR DESCRIPTION
Uint 2.0.1 is just a wrapper around stdint, so upgrading no longer requires an API change.

Fixes #9.