### PR TITLE
Explore interfaces in find_interesting_import_ids

### DIFF
--- a/src/compiler/genCommon.ml
+++ b/src/compiler/genCommon.ml
@@ -427,17 +427,7 @@ and union_imports_for_type ~visited_node_ids ~import_ids ~context (tp : PS.Type.
       begin match Hashtbl.add visited_node_ids ~key:struct_id ~data:() with
       | `Ok ->
           let struct_node = Context.node context struct_id in
-          let () = begin match PS.Node.get struct_node with
-          | PS.Node.Struct struct_descr ->
-              union_imports_for_struct_fields ~visited_node_ids ~import_ids
-                ~context struct_descr
-          | _ ->
-              failwith "found non-struct node where struct node was expected"
-          end in
-          begin match find_import_providing_node ~context struct_node with
-          | Some import -> Hashtbl.set import_ids ~key:import.Context.id ~data:()
-          | None -> ()
-          end
+          union_imports_for_struct ~visited_node_ids ~import_ids ~context struct_node
       | `Duplicate ->
           ()
       end
@@ -451,6 +441,19 @@ and union_imports_for_type ~visited_node_ids ~import_ids ~context (tp : PS.Type.
       end
   | Undefined x ->
       failwith (sprintf "Unknown Type union discriminant %d" x)
+
+
+and union_imports_for_struct ~visited_node_ids ~import_ids ~context struct_node =
+  match PS.Node.get struct_node with
+  | PS.Node.Struct struct_descr ->
+    union_imports_for_struct_fields ~visited_node_ids ~import_ids
+      ~context struct_descr;
+    begin match find_import_providing_node ~context struct_node with
+      | Some import -> Hashtbl.set import_ids ~key:import.Context.id ~data:()
+      | None -> ()
+    end
+  | _ ->
+    failwith "found non-struct node where struct node was expected"
 
 
 (** Not all imports contain interesting content.  In particular, the

--- a/src/compiler/genCommon.ml
+++ b/src/compiler/genCommon.ml
@@ -443,6 +443,16 @@ and union_imports_for_type ~visited_node_ids ~import_ids ~context (tp : PS.Type.
       failwith (sprintf "Unknown Type union discriminant %d" x)
 
 
+and union_imports_for_iface_methods ~visited_node_ids ~import_ids ~context iface =
+  let methods = PS.Node.Interface.methods_get iface in
+  C.Array.iter methods ~f:(fun meth ->
+      let params = Context.node context (PS.Method.param_struct_type_get meth) in
+      union_imports_for_struct ~context ~visited_node_ids ~import_ids params;
+      let results = Context.node context (PS.Method.result_struct_type_get meth) in
+      union_imports_for_struct ~context ~visited_node_ids ~import_ids results;
+    )
+
+
 and union_imports_for_struct ~visited_node_ids ~import_ids ~context struct_node =
   match PS.Node.get struct_node with
   | PS.Node.Struct struct_descr ->
@@ -486,9 +496,13 @@ and find_interesting_import_ids ~visited_node_ids ~import_ids ~context node =
           end
       | PS.Node.Enum _
       | PS.Node.File
-      | PS.Node.Annotation _
-      | PS.Node.Interface _ ->
-          (* FIXME: recurse here when interfaces are complete *)
+      | PS.Node.Annotation _ ->
+          begin match find_import_providing_node ~context node with
+          | Some import -> Hashtbl.set import_ids ~key:import.Context.id ~data:()
+          | None -> ()
+          end
+      | PS.Node.Interface iface ->
+          union_imports_for_iface_methods ~visited_node_ids ~import_ids ~context iface;
           begin match find_import_providing_node ~context node with
           | Some import -> Hashtbl.set import_ids ~key:import.Context.id ~data:()
           | None -> ()

--- a/src/tests/dune
+++ b/src/tests/dune
@@ -4,48 +4,21 @@
  (flags :standard -w -53))
 
 (rule
- (targets test.ml test.mli)
+ (targets
+  test.ml               test.mli
+  test_import.ml        test_import.mli
+  c2b2b.ml              c2b2b.mli
+  testLists.ml          testLists.mli
+  testCycles.ml         testCycles.mli)
  (deps
-  (:< test.capnp)
-  ../compiler/main.bc)
+  c++.capnp
+  test.capnp
+  test-import.capnp
+  testLists.capnp
+  testCycles.capnp)
  (action
-  (run capnpc -o ../compiler/main.bc %{<})))
-
-(rule
- (targets test_import.ml test_import.mli)
- (deps
-  (:< test-import.capnp)
-  ../compiler/main.bc)
- (action
-  (run capnpc -o ../compiler/main.bc %{<})))
-
-(rule
- (targets c2b2b.ml c2b2b.mli)
- (deps
-  (:< c++.capnp)
-  ../compiler/main.bc)
- (action
-  (run capnpc -o ../compiler/main.bc %{<})))
-
-(rule
- (targets testLists.ml testLists.mli)
- (deps
-  (:< testLists.capnp)
-  ../compiler/main.bc)
- (action
-  (run capnpc -o ../compiler/main.bc %{<})))
-
-(rule
- (targets testCycles.ml testCycles.mli)
- (deps
-  (:< testCycles.capnp)
-  ../compiler/main.bc)
- (action
-  (run capnpc -o ../compiler/main.bc %{<})))
+  (run capnpc -o %{bin:capnpc-ocaml} %{deps})))
 
 (alias
  (name runtest)
- (deps
-  (:< run_tests.bc))
- (action
-  (run %{<})))
+ (action (run %{exe:run_tests.bc})))

--- a/src/tests/dune
+++ b/src/tests/dune
@@ -6,6 +6,7 @@
 (rule
  (targets
   test.ml               test.mli
+  test_iface_import.ml  test_iface_import.mli
   test_import.ml        test_import.mli
   c2b2b.ml              c2b2b.mli
   testLists.ml          testLists.mli
@@ -14,6 +15,7 @@
   c++.capnp
   test.capnp
   test-import.capnp
+  test-iface-import.capnp
   testLists.capnp
   testCycles.capnp)
  (action

--- a/src/tests/test-iface-import.capnp
+++ b/src/tests/test-iface-import.capnp
@@ -1,0 +1,7 @@
+@0x9b5510fa58929c52;
+
+using Test = import "test.capnp";
+
+interface TestIfaceImport {
+  m0  @0 (x :Test.TestAllTypes);
+}

--- a/src/tests/testEncoding.ml
+++ b/src/tests/testEncoding.ml
@@ -41,6 +41,7 @@ module BM  = Capnp.BytesMessage
 module T   = Test.Make(BM)
 module TL  = TestLists.Make(BM)
 module TI  = Test_import.Make(BM)
+module TII = Test_iface_import.Make(BM)
 
 open OUnit2
 
@@ -1451,6 +1452,14 @@ let test_imports _ctx =
   in
   ()
 
+let test_iface_imports _ctx =
+  let module Builder = TII.Builder.TestIfaceImport.M0.Params in
+  let root = Builder.init_root () in
+  init_test_message (Builder.x_init root);
+  let reader = Builder.to_reader root in
+  let module Reader = TII.Reader.TestIfaceImport.M0.Params in
+  Reader_check_test_message.f (Reader.x_get reader)
+
 let test_constants _ctx =
   let open T.Reader.TestConstants in
   assert_equal () void_const;
@@ -1666,6 +1675,7 @@ let encoding_suite =
     "upgrade list in builder" >:: test_upgrade_list_in_builder;
     "nested types encoding" >:: test_nested_types_encoding;
     "test imports" >:: test_imports;
+    "test iface imports" >:: test_iface_imports;
     "test constants" >:: test_constants;
     "test global constants" >:: test_global_constants;
     "test int accessors" >:: test_int_accessors;


### PR DESCRIPTION
Before, we didn't recognise imported structs or interfaces that were referenced from method parameters or results. There was a `FIXME` in the code about this.

The unit-test added by this PR fails with the original code with the error:

    File "src/tests/test_iface_import.mli", line 25, characters 27-41:
    25 |           val x_get : t -> TestAllTypes.t
                                    ^^^^^^^^^^^^^^
    Error: Unbound module TestAllTypes

With the change, the generated line is:

    val x_get : t -> [`TestAllTypes_a0a8f314b80b63fd] reader_t