### PR TITLE
Dune should not be a build dependency

### DIFF
--- a/capnp.opam
+++ b/capnp.opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/capnproto/capnp-ocaml"
 bug-reports: "https://github.com/capnproto/capnp-ocaml/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "result"
   "base" {>= "v0.11"}
   "stdio"


### PR DESCRIPTION
Reported by Marcello Seri.