### PR TITLE
Implement pooling of message buffers

### DIFF
--- a/src/runtime/codecs.ml
+++ b/src/runtime/codecs.ml
@@ -298,6 +298,25 @@ let serialize_iter message ~compression ~f =
   serialize_fold message ~compression ~init:() ~f:(fun () s -> f s)
 
 
+let serialize_fold_copyless message ~compression ~init ~f = 
+  let segment_descrs = Message.BytesMessage.Message.to_storage message in
+  match compression with
+  | `None ->
+      let header = make_header segment_descrs in
+      ListLabels.fold_left segment_descrs ~init:(f init header (String.length header)) ~f:(fun acc descr ->
+        let open Message.BytesMessage in
+        f acc (Bytes.unsafe_to_string descr.Message.segment) descr.Message.bytes_consumed )
+  | `Packing ->
+      serialize_fold message ~compression:`None ~init
+        ~f:(fun acc unpacked_fragment ->
+            let packed_string = Packing.pack_string unpacked_fragment in
+          f acc packed_string (String.length packed_string))
+
+
+let serialize_iter_copyless message ~compression ~f =
+  serialize_fold_copyless message ~compression ~init:() ~f:(fun () s -> f s)
+
+
 let rec serialize ~compression message =
   match compression with
   | `None ->

--- a/src/runtime/codecs.mli
+++ b/src/runtime/codecs.mli
@@ -87,6 +87,20 @@ val serialize_fold : 'cap Message.BytesMessage.Message.t ->
 val serialize_iter : 'cap Message.BytesMessage.Message.t ->
   compression:compression_t -> f:(string -> unit) -> unit
 
+(** [serialize_fold_copyless message ~compression ~init ~f] exposes an ordered sequence
+    of string fragments (and lengths) corresponding to a Cap'n Proto framed message, encoded
+    using the specified [compression] method.  The return value is the result
+    of folding [f] across the resulting sequence of fragments. *)
+val serialize_fold_copyless : 'cap Message.BytesMessage.Message.t ->
+  compression:compression_t -> init:'acc -> f:('acc -> string -> int -> 'acc) -> 'acc
+
+(** [serialize_iter_copyless message ~compression ~f] exposes an ordered sequence of
+    string fragments (and lengths) corresponding to a Cap'n Proto framed message, encoded
+    using the specified [compression] method.  [f] is applied to each fragment
+    in turn. *)
+val serialize_iter_copyless : 'cap Message.BytesMessage.Message.t ->
+  compression:compression_t -> f:(string -> int -> unit) -> unit
+
 (** [serialize ~compression message] constructs a string containing the [message]
     segments prefixed with the serialization framing header, encoded using the
     specified [compression] method. *)

--- a/src/tests/testCodecs.ml
+++ b/src/tests/testCodecs.ml
@@ -4,8 +4,7 @@
  * Copyright (c) 2013-2014, Paul Pelzl
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
  *
  *  1. Redistributions of source code must retain the above copyright notice,
  *     this list of conditions and the following disclaimer.
@@ -202,6 +201,44 @@ let test_random_serialize_deserialize _ctx =
     | Result.Error _ ->
         assert false)
 
+let test_random_serialize_deserialize_fold _ctx =
+  laws_exn "deserialize(fragment(serialize(x))) = x"
+      2000 (Quickcheck.Generator.both message_gen capnp_string_gen) (fun (m, trailing_data) ->
+    let open Capnp.Runtime in
+    let ser_fragments = Codecs.FramedStream.empty `None in
+    Codecs.serialize_fold m ~compression:`None ~init:() 
+        ~f:(fun () fragment -> 
+            Codecs.FramedStream.add_fragment ser_fragments fragment
+        );
+    let () = Codecs.FramedStream.add_fragment ser_fragments trailing_data in
+    match Codecs.FramedStream.get_next_frame ser_fragments with
+    | Result.Ok decoded_message ->
+        let () = assert (Codecs.FramedStream.bytes_available ser_fragments =
+          (String.length trailing_data)) in
+        (Capnp.Message.BytesMessage.Message.to_storage m) =
+          (Capnp.Message.BytesMessage.Message.to_storage decoded_message)
+    | Result.Error _ ->
+        assert false)
+
+let test_random_serialize_deserialize_fold_copyless _ctx =
+  laws_exn "deserialize(fragment(serialize(x))) = x"
+      2000 (Quickcheck.Generator.both message_gen capnp_string_gen) (fun (m, trailing_data) ->
+    let open Capnp.Runtime in
+    let ser_fragments = Codecs.FramedStream.empty `None in
+    Codecs.serialize_fold_copyless m ~compression:`None ~init:() 
+        ~f:(fun () fragment len -> 
+            let fragment = String.sub fragment 0 len in
+            Codecs.FramedStream.add_fragment ser_fragments fragment
+        );
+    let () = Codecs.FramedStream.add_fragment ser_fragments trailing_data in
+    match Codecs.FramedStream.get_next_frame ser_fragments with
+    | Result.Ok decoded_message ->
+        let () = assert (Codecs.FramedStream.bytes_available ser_fragments =
+          (String.length trailing_data)) in
+        (Capnp.Message.BytesMessage.Message.to_storage m) =
+          (Capnp.Message.BytesMessage.Message.to_storage decoded_message)
+    | Result.Error _ ->
+        assert false)
 
 let test_random_serialize_deserialize_packed _ctx =
   laws_exn "deserialize_unpack(fragment(serialize_pack(x))) = x"
@@ -221,6 +258,8 @@ let test_random_serialize_deserialize_packed _ctx =
 let random_serialize_suite =
   "random_serialization_deserialization" >::: [
     "serialize_deserialize_message" >:: test_random_serialize_deserialize;
+    "serialize_deserialize_fold_message" >:: test_random_serialize_deserialize_fold;
+    "serialize_deserialize_fold_copyless_message" >:: test_random_serialize_deserialize_fold_copyless;
     "serialize_deserialize_packed_message" >:: test_random_serialize_deserialize_packed;
   ]
 


### PR DESCRIPTION
In the current api there is the capability to pool message buffers: 
```
Message.Make(...) = sig
val alloc : ...
val release: ...
```

This PR implements this functionality by use of the `buffer-pool-min` package. The use of `buffer-pool-min` rather than `buffer-pool` allows for no breaking API changes, however there will be memory leak style behavior with randomly sized messages.

The main benefit of this is for workloads which mainly involve similarly sized messages. This would allow them to minimise the GC work done ([currently ~50% of the CPU time is spent on GC...](https://discuss.ocaml.org/t/diagnosing-large-amounts-of-time-spent-in-gc/5747/11)).

~~The implementation of a pooled store, however some of the tests are not passing and I am not sure why yet...~~