### PR TITLE
Remove incorrect test for 64-bit on Windows

### DIFF
--- a/src/benchmark/fastRand/fast_rand.c
+++ b/src/benchmark/fastRand/fast_rand.c
@@ -32,7 +32,9 @@
 
 // This code is designed for use on a 64-bit platform, where a uint32_t
 // always fits inside an OCaml int.
-static char requires_sixtyfour_bit_platform[sizeof(long) == 8 ? 1 : -1];
+#ifndef ARCH_SIXTYFOUR
+#error "This code is designed for use on a 64-bit platform"
+#endif
 
 // Use a 128-bit Xorshift algorithm.
 static inline uint32_t nextFastRand() {


### PR DESCRIPTION
Very minor fix - `long` is always 32-bits on Windows. Given that the idea is to have an error on a 32-bit system, how about this instead? The other option would be to keep the existing code but use `SIZEOF_PTR` (from `m.h` which is included by `caml/mlvalues.h`)