### PR TITLE
Remove compiler flags for flambda

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ Documentation:
 
 Build system:
 
+* Remove compiler flags for flambda (@talex5, #83).
+  This was very slow to compile on OCaml 4.14, and the performance benefit is minimal.
+
 * Update to dune 2 (@talex5, #77).
 
 * Dune should not be a build dependency (@talex5, #67).

--- a/src/benchmark/test.py
+++ b/src/benchmark/test.py
@@ -3,7 +3,7 @@ import subprocess, os, csv, time, sys
 my_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
 os.chdir(my_dir)
 
-subprocess.check_call(["dune", "build", "carsales", "catrank", "eval"])
+subprocess.check_call(["dune", "build", "--profile=release", "carsales", "catrank", "eval"])
 bin_dir = os.path.join(my_dir, '../../_build/default/src/benchmark')
 
 switch = subprocess.check_output(["opam", "sw", "show"]).strip()

--- a/src/runtime/dune
+++ b/src/runtime/dune
@@ -3,5 +3,4 @@
  (public_name capnp)
  (synopsis "Runtime support library for capnp-ocaml")
  (libraries result stdint ocplib-endian res)
- (flags :standard -w -50-53-55)
- (ocamlopt_flags :standard -O3 -inline 1000))
+ (flags :standard -w -50-53-55))

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -3,5 +3,4 @@
  (public_name capnp.unix)
  (synopsis "Runtime support library for capnp-ocaml (Unix)")
  (libraries capnp unix base stdio)
- (flags :standard -w -50-53-55)
- (ocamlopt_flags :standard -O3 -inline 1000))
+ (flags :standard -w -50-53-55))


### PR DESCRIPTION
This was needed to get flambda to inline the functor, but I don't think anyone is using flambda and it massively slows down the build for everyone else. We can try optimising it again once flambda2 is ready.

On OCaml 4.13 on my machine, this reduced the build time from 16s to 3s (tested with `rm -rf _build && time dune build --release`).