### PR TITLE
Minor opam fixes

### DIFF
--- a/capnp.opam
+++ b/capnp.opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/capnproto/capnp-ocaml/issues"
 license: "BSD-2-Clause"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {>= "2.0"}
+  "dune" {>= "2.3"}
   "result"
   "base" {>= "v0.11"}
   "stdio"
@@ -20,7 +20,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "build" "-p" name "-j" jobs "@runtest" "@src/benchmark/benchmarks"] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
 ]
 dev-repo: "git+https://github.com/capnproto/capnp-ocaml.git"
 synopsis:


### PR DESCRIPTION
- Depend on dune >= 2.3
- Don't try to build benchmarks; that only works on some platforms.