### PR TITLE
Fix "Unknown interface" error

### DIFF
--- a/src/compiler/genModules.ml
+++ b/src/compiler/genModules.ml
@@ -1813,7 +1813,7 @@ let generate_service ~context ~nested_modules ~node_name ~interface_node interfa
     [ "class virtual service = object (self)";
       "  method release = ()";
       "  method dispatch ~interface_id:i ~method_id =";
-      "    if i <> interface_id then MessageWrapper.Untyped.unknown_interface ~interface_id";
+      "    if i <> interface_id then MessageWrapper.Untyped.unknown_interface ~interface_id:i";
       "    else match method_id with";
     ] @ apply_indent ~indent:"    " dispatch_body @
     [ "    | x -> MessageWrapper.Untyped.unknown_method ~interface_id ~method_id";

--- a/src/runtime/rPC.ml
+++ b/src/runtime/rPC.ml
@@ -11,6 +11,8 @@ module Registry : sig
       It prints out qualified names, suitable for logging
       (e.g. "Foo.bar") *)
   val pp_method : Format.formatter -> Uint64.t * int -> unit
+
+  val pp_interface : Format.formatter -> Uint64.t -> unit
 end = struct
   type interface = {
     name : string;
@@ -34,6 +36,11 @@ end = struct
         Format.fprintf f "%s.%s" interface.name method_name
       | None ->
         Format.fprintf f "%s.<method-%d>" interface.name method_id
+
+  let pp_interface f interface_id =
+    match Hashtbl.find interfaces interface_id with
+    | exception Not_found -> Format.fprintf f "<interface %a>" Uint64.printer interface_id
+    | interface           -> Format.fprintf f "%s" interface.name
 end
 
 module MethodID : sig


### PR DESCRIPTION
It reported the ID of the actual object, not the ID that was requested.

Also, add pretty-printer for interfaces from the registry.