### PR TITLE
Fix invalid doc-comments and inline attributes

### DIFF
--- a/capnp.opam
+++ b/capnp.opam
@@ -15,7 +15,7 @@ depends: [
   "ocplib-endian" {>= "0.7"}
   "res"
   "stdint" {>= "0.5.1"}
-  "ounit" {with-test}
+  "ounit2" {with-test}
   "conf-capnproto" {with-test}
 ]
 build: [

--- a/src/benchmark/capnpCarsales.ml
+++ b/src/benchmark/capnpCarsales.ml
@@ -1,5 +1,5 @@
 
-module CS = Carsales.Make[@inlined](Capnp.BytesMessage)
+module CS = Carsales.Make(Capnp.BytesMessage)
 
 module TestCase = struct
   type request_t     = CS.Reader.ParkingLot.struct_t

--- a/src/benchmark/capnpCatrank.ml
+++ b/src/benchmark/capnpCatrank.ml
@@ -1,7 +1,7 @@
 
 module CamlBytes = Bytes
 
-module CR = Catrank.Make[@inlined](Capnp.BytesMessage)
+module CR = Catrank.Make(Capnp.BytesMessage)
 
 module Array = Base.Array
 module Char = Base.Char

--- a/src/benchmark/capnpEval.ml
+++ b/src/benchmark/capnpEval.ml
@@ -1,5 +1,5 @@
 
-module E = Eval.Make[@inlined](Capnp.BytesMessage)
+module E = Eval.Make(Capnp.BytesMessage)
 
 module Int32 = Base.Int32
 

--- a/src/benchmark/dune
+++ b/src/benchmark/dune
@@ -2,7 +2,7 @@
  (name main)
  (enabled_if (= %{architecture} amd64))
  (libraries capnp capnp_unix fast_rand base)
- (flags :standard -w -53-55)
+ (flags :standard -w -55)
  (ocamlopt_flags :standard -O3 -inline 2000))
 
 (rule

--- a/src/compiler/dune
+++ b/src/compiler/dune
@@ -1,5 +1,5 @@
 (executable
  (name main)
  (public_name capnpc-ocaml)
- (flags :standard -w -53-55)
+ (flags :standard -w -55)
  (libraries capnp capnp_unix))

--- a/src/compiler/generate.ml
+++ b/src/compiler/generate.ml
@@ -122,7 +122,7 @@ let mod_functor_header = [
 let mod_header ~context = [
   "  let invalid_msg = Capnp.Message.invalid_msg";
   "";
-  "  include Capnp.Runtime.BuilderInc.Make[@inlined](MessageWrapper)";
+  "  include Capnp.Runtime.BuilderInc.Make(MessageWrapper)";
   "";
   "  type 'cap message_t = 'cap MessageWrapper.Message.t";
   ""; ] @ (List.concat_map context.Context.imports ~f:(fun import -> [
@@ -169,7 +169,7 @@ let mod_footer = [
 
 let mod_functor_footer = [
   "  module MessageWrapper = MessageWrapper";
-  "end [@@inline]";
+  "end";
   "";
   "module Make(M:Capnp.MessageSig.S) = MakeRPC[@inlined](Capnp.RPC.None(M)) [@@inline]";
 ]

--- a/src/compiler/pluginSchema.ml
+++ b/src/compiler/pluginSchema.ml
@@ -1358,7 +1358,7 @@ module MakeRPC(MessageWrapper : Capnp.RPC.S) = struct
 
   let invalid_msg = Capnp.Message.invalid_msg
 
-  include Capnp.Runtime.BuilderInc.Make[@inlined](MessageWrapper)
+  include Capnp.Runtime.BuilderInc.Make(MessageWrapper)
 
   type 'cap message_t = 'cap MessageWrapper.Message.t
 
@@ -4085,4 +4085,4 @@ module MakeRPC(MessageWrapper : Capnp.RPC.S) = struct
   module MessageWrapper = MessageWrapper
 end [@@inline]
 
-module Make(M:Capnp.MessageSig.S) = MakeRPC[@inlined](Capnp.RPC.None(M)) [@@inline]
+module Make(M:Capnp.MessageSig.S) = MakeRPC(Capnp.RPC.None(M)) [@@inline]

--- a/src/examples/1/dune
+++ b/src/examples/1/dune
@@ -1,10 +1,9 @@
 (executable
   (name example1)
   (libraries capnp)
-  ; We want to disable warnings 53 to 55 (see: http://caml.inria.fr/pub/docs/manual-ocaml/toplevel.html)
   ; We disable warning 55 as this relates to inlining certain functions. For inlining please see the README.md 
   ; and the benchmarks for examples.
-  (flags :standard -w -53-55))
+  (flags :standard -w -55))
 
 ; This rule tells dune how to generate foo.ml and foo.mli by compiling foo.capnp against the CAP'N PROTO compiler
 ; PLEASE NOTE that capnpc must exist on your computer for this to work (https://capnproto.org/install.html)

--- a/src/examples/2/dune
+++ b/src/examples/2/dune
@@ -1,7 +1,7 @@
 (executable
   (name example2)
   (libraries capnp)
-  (flags :standard -w -53-55))
+  (flags :standard -w -55))
 
 (rule
   (targets shape.ml shape.mli)

--- a/src/runtime/builderInc.ml
+++ b/src/runtime/builderInc.ml
@@ -46,7 +46,7 @@ let sizeof_uint64 = 8
 (* Functor parameter: NM == "native message" *)
 module Make (NM : RPC.S) = struct
   module RA_ = struct
-    include ReaderInc.Make[@inlined](NM)
+    include ReaderInc.Make(NM)
   end
 
   module BA_ = struct
@@ -56,7 +56,7 @@ module Make (NM : RPC.S) = struct
     module DM = Message.BytesMessage
 
     module NC = struct
-      include CommonInc.Make[@inlined](NM)
+      include CommonInc.Make(NM)
     end
 
     (* DefaultsCopier will provide algorithms for making deep copies of default

--- a/src/runtime/builderOps.ml
+++ b/src/runtime/builderOps.ml
@@ -51,9 +51,9 @@ end
    cases are functions that make a copy from a source to a destination. *)
 module Make (ROM : MessageSig.S) (RWM : RPC.S) = struct
   module ROM = RPC.None(ROM)
-  module ROC = CommonInc.Make[@inlined](ROM)
-  module RWC = CommonInc.Make[@inlined](RWM)
-  module RReader = ReaderInc.Make[@inlined](RWM)
+  module ROC = CommonInc.Make(ROM)
+  module RWC = CommonInc.Make(RWM)
+  module RReader = ReaderInc.Make(RWM)
 
 
   (* Given storage for a struct, get the pointer bytes for the given

--- a/src/runtime/codecs.ml
+++ b/src/runtime/codecs.ml
@@ -50,11 +50,11 @@ module UncompStream = struct
     | IncompleteFrame of incomplete_frame_t
 
   type t = {
-    (** Primary storage for incoming stream segments. *)
     fragment_buffer : FragmentBuffer.t;
+    (** Primary storage for incoming stream segments. *)
 
-    (** Partially-decoded frame information *)
     mutable decoder_state : decoder_state_t;
+    (** Partially-decoded frame information *)
   }
 
   let empty () = {
@@ -164,11 +164,11 @@ end
 module PackedStream = struct
 
   type t = {
-    (** Packed fragments waiting to be unpacked *)
     packed : FragmentBuffer.t;
+    (** Packed fragments waiting to be unpacked *)
 
-    (** Unpacked fragments waiting to be decoded as messages *)
     unpacked : UncompStream.t;
+    (** Unpacked fragments waiting to be decoded as messages *)
   }
 
   let empty () = {

--- a/src/runtime/dune
+++ b/src/runtime/dune
@@ -3,4 +3,4 @@
  (public_name capnp)
  (synopsis "Runtime support library for capnp-ocaml")
  (libraries result stdint ocplib-endian res)
- (flags :standard -w -50-53-55))
+ (flags :standard -w -53-55))

--- a/src/runtime/dune
+++ b/src/runtime/dune
@@ -3,4 +3,4 @@
  (public_name capnp)
  (synopsis "Runtime support library for capnp-ocaml")
  (libraries result stdint ocplib-endian res)
- (flags :standard -w -53-55))
+ (flags :standard -w -55))

--- a/src/runtime/farPointer.ml
+++ b/src/runtime/farPointer.ml
@@ -33,15 +33,15 @@ type landing_pad_t =
   | TaggedFarPointer
 
 type t = {
-  (** Type of landing pad which this far pointer points to. *)
   landing_pad : landing_pad_t;
+  (** Type of landing pad which this far pointer points to. *)
 
+  offset : int;
   (** Unsigned offset in words from start of the segment to start of
       the landing pad. *)
-  offset : int;
 
-  (** Segment ID where the landing pad is located. *)
   segment_id : int
+  (** Segment ID where the landing pad is located. *)
 }
 
 

--- a/src/runtime/fragmentBuffer.ml
+++ b/src/runtime/fragmentBuffer.ml
@@ -34,11 +34,11 @@ type fragment = {
 }
 
 type t = {
-  (** String fragments stored in FIFO order *)
   mutable ends : (fragment * fragment) option;     (* Front, back *)
+  (** String fragments stored in FIFO order *)
 
-  (** Total byte count of the fragments *)
   mutable fragments_size : int;
+  (** Total byte count of the fragments *)
 }
 
 let empty () = {

--- a/src/runtime/listPointer.ml
+++ b/src/runtime/listPointer.ml
@@ -11,16 +11,16 @@ type element_type_t =
 
 
 type t = {
+  offset : int;
   (** Signed offset in words from end of the pointer to start of the first
       list element. *)
-  offset : int;
 
-  (** Type of data stored for each list element. *)
   element_type : element_type_t;
+  (** Type of data stored for each list element. *)
 
+  num_elements : int;
   (** Number of elements in the list.  For Composite list data, this is the number
       of words in the list. *)
-  num_elements : int;
 }
 
 

--- a/src/runtime/listStorageType.ml
+++ b/src/runtime/listStorageType.ml
@@ -2,24 +2,24 @@
 let sizeof_uint64 = 8
 
 type t =
-  (** list(void), no storage required *)
   | Empty
+  (** list(void), no storage required *)
 
-  (** list(bool), tightly packed bits *)
   | Bit
+  (** list(bool), tightly packed bits *)
 
-  (** either primitive values or a data-only struct *)
   | Bytes1
   | Bytes2
   | Bytes4
   | Bytes8
+  (** either primitive values or a data-only struct *)
 
-  (** either a pointer to an external object, or a pointer-only struct *)
   | Pointer
+  (** either a pointer to an external object, or a pointer-only struct *)
 
+  | Composite of int * int
   (** typical struct; parameters are per-element word size for data section
       and pointers section, respectively *)
-  | Composite of int * int
 
 let get_byte_count storage_type =
   match storage_type with

--- a/src/runtime/messageSig.ml
+++ b/src/runtime/messageSig.ml
@@ -136,11 +136,11 @@ module type MESSAGE = sig
   type storage_t
 
   type storage_descr_t = {
-    (** Storage for one of the message segments *)
     segment : storage_t;
+    (** Storage for one of the message segments *)
 
-    (** Number of bytes actually consumed in this segment *)
     bytes_consumed : int;
+    (** Number of bytes actually consumed in this segment *)
   }
 
   type -'cap segment_t

--- a/src/runtime/readerInc.ml
+++ b/src/runtime/readerInc.ml
@@ -39,7 +39,7 @@ let sizeof_uint64 = 8
 open Message
 
 module Make (MessageWrapper : RPC.S) = struct
-  module RC = CommonInc.Make[@inlined](MessageWrapper)
+  module RC = CommonInc.Make(MessageWrapper)
   include RC
 
   (* Given a pointer which is expected to be a list pointer, compute the

--- a/src/runtime/structPointer.ml
+++ b/src/runtime/structPointer.ml
@@ -29,15 +29,15 @@
 
 
 type t = {
+  offset : int;
   (** Signed offset in words from end of the pointer to start of struct
       data region. *)
-  offset : int;
 
-  (** Size of struct data region, in words. *)
   data_words : int;
+  (** Size of struct data region, in words. *)
 
-  (** Size of struct pointers region, in words. *)
   pointer_words : int;
+  (** Size of struct pointers region, in words. *)
 }
 
 

--- a/src/tests/dune
+++ b/src/tests/dune
@@ -1,7 +1,7 @@
 (test
  (name run_tests)
  (libraries capnp ounit2 base_quickcheck)
- (flags :standard -w -53-55))
+ (flags :standard -w -55))
 
 (rule
  (targets

--- a/src/tests/dune
+++ b/src/tests/dune
@@ -1,6 +1,6 @@
 (test
  (name run_tests)
- (libraries capnp oUnit base_quickcheck)
+ (libraries capnp ounit2 base_quickcheck)
  (flags :standard -w -53-55))
 
 (rule

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -3,4 +3,4 @@
  (public_name capnp.unix)
  (synopsis "Runtime support library for capnp-ocaml (Unix)")
  (libraries capnp unix base stdio)
- (flags :standard -w -50-53-55))
+ (flags :standard -w -53-55))

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -3,4 +3,4 @@
  (public_name capnp.unix)
  (synopsis "Runtime support library for capnp-ocaml (Unix)")
  (libraries capnp unix base stdio)
- (flags :standard -w -53-55))
+ (flags :standard -w -55))

--- a/src/unix/iO.ml
+++ b/src/unix/iO.ml
@@ -37,23 +37,23 @@ exception Unsupported_message_frame
 
 module WriteContext = struct
   type 'a t = {
-    (** File descriptor we're writing to *)
     fd : 'a;
+    (** File descriptor we're writing to *)
 
-    (** Compression format *)
     comp : compression_t;
+    (** Compression format *)
 
-    (** Function for writing to the descriptor *)
     write : 'a -> buf:string -> pos:int -> len:int -> int;
+    (** Function for writing to the descriptor *)
 
-    (** Data remaining to write to the descriptor *)
     fragments : string Queue.t;
+    (** Data remaining to write to the descriptor *)
 
-    (** Total number of bytes stored in [fragments] *)
     mutable fragments_size : int;
+    (** Total number of bytes stored in [fragments] *)
 
-    (** Position within the first fragment where writing should begin *)
     mutable first_fragment_pos : int;
+    (** Position within the first fragment where writing should begin *)
   }
 
   let create ~write ~compression fd = {
@@ -108,17 +108,17 @@ end
 
 module ReadContext = struct
   type 'a t = {
-    (** File descriptor we're writing to *)
     fd : 'a;
+    (** File descriptor we're writing to *)
 
-    (** Stream format *)
     stream : Codecs.FramedStream.t;
+    (** Stream format *)
 
-    (** Function for reading from the descriptor *)
     read : 'a -> buf:Bytes.t -> pos:int -> len:int -> int;
+    (** Function for reading from the descriptor *)
 
-    (** Persistent read buffer *)
     read_buf : Bytes.t;
+    (** Persistent read buffer *)
   }
 
   let create ~read ~compression fd = {


### PR DESCRIPTION
- Comments need to go after the fields, not before.
- Removed some inlining attributes; even flambda (with OCaml 5.0.0) complains about these now!
- Fixed dependency on ounit2 (lower-bounds check was failing).

