### PR TITLE
Remove all `inlined` attributes

### DIFF
--- a/src/benchmark/dune
+++ b/src/benchmark/dune
@@ -2,7 +2,6 @@
  (name main)
  (enabled_if (= %{architecture} amd64))
  (libraries capnp capnp_unix fast_rand base)
- (flags :standard -w -55)
  (ocamlopt_flags :standard -O3 -inline 2000))
 
 (rule

--- a/src/compiler/dune
+++ b/src/compiler/dune
@@ -1,5 +1,4 @@
 (executable
  (name main)
  (public_name capnpc-ocaml)
- (flags :standard -w -55)
  (libraries capnp capnp_unix))

--- a/src/compiler/generate.ml
+++ b/src/compiler/generate.ml
@@ -171,7 +171,7 @@ let mod_functor_footer = [
   "  module MessageWrapper = MessageWrapper";
   "end";
   "";
-  "module Make(M:Capnp.MessageSig.S) = MakeRPC[@inlined](Capnp.RPC.None(M)) [@@inline]";
+  "module Make(M:Capnp.MessageSig.S) = MakeRPC(Capnp.RPC.None(M))";
 ]
 
 

--- a/src/examples/1/dune
+++ b/src/examples/1/dune
@@ -1,9 +1,6 @@
 (executable
   (name example1)
-  (libraries capnp)
-  ; We disable warning 55 as this relates to inlining certain functions. For inlining please see the README.md 
-  ; and the benchmarks for examples.
-  (flags :standard -w -55))
+  (libraries capnp))
 
 ; This rule tells dune how to generate foo.ml and foo.mli by compiling foo.capnp against the CAP'N PROTO compiler
 ; PLEASE NOTE that capnpc must exist on your computer for this to work (https://capnproto.org/install.html)

--- a/src/examples/2/dune
+++ b/src/examples/2/dune
@@ -1,7 +1,6 @@
 (executable
   (name example2)
-  (libraries capnp)
-  (flags :standard -w -55))
+  (libraries capnp))
 
 (rule
   (targets shape.ml shape.mli)

--- a/src/runtime/dune
+++ b/src/runtime/dune
@@ -2,5 +2,4 @@
  (name capnp)
  (public_name capnp)
  (synopsis "Runtime support library for capnp-ocaml")
- (libraries result stdint ocplib-endian res)
- (flags :standard -w -55))
+ (libraries result stdint ocplib-endian res))

--- a/src/runtime/message.ml
+++ b/src/runtime/message.ml
@@ -415,7 +415,7 @@ module Make (Storage : MessageStorage.S) = struct
 
 end [@@inline]
 
-module BytesMessage = Make[@inlined](BytesStorage)
+module BytesMessage = Make(BytesStorage)
 
 
 exception Invalid_message of string

--- a/src/tests/dune
+++ b/src/tests/dune
@@ -1,7 +1,6 @@
 (test
  (name run_tests)
- (libraries capnp ounit2 base_quickcheck)
- (flags :standard -w -55))
+ (libraries capnp ounit2 base_quickcheck))
 
 (rule
  (targets

--- a/src/unix/dune
+++ b/src/unix/dune
@@ -2,5 +2,4 @@
  (name capnp_unix)
  (public_name capnp.unix)
  (synopsis "Runtime support library for capnp-ocaml (Unix)")
- (libraries capnp unix base stdio)
- (flags :standard -w -55))
+ (libraries capnp unix base stdio))


### PR DESCRIPTION
These cause confusing compiler warnings for users, which can't be disabled automatically, and the inlining isn't being used anyway since https://github.com/capnproto/capnp-ocaml/pull/83.