### PR TITLE
Hygiene: Add MESSAGE_STORAGE. No leak Uint32/64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _build
+_opam
 .merlin
 capnp.install

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# PENDING
+
+New features:
+
+- Expose module type `MESSAGE_STORAGE` which was used as a `Capnp.Message.Make`
+  functor parameter but was previously hidden in `Capnp__MessageStorage.S`.
+  Stop leaking `Uint32` and `Uint64` in module types. (@jonahbeckford #91)
+
 # v3.6.0
 
 - Update README to talk about stdint, not uint (reported by @liyishuai).  

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ New features:
 
 - Expose module type `MESSAGE_STORAGE` which was used as a `Capnp.Message.Make`
   functor parameter but was previously hidden in `Capnp__MessageStorage.S`.
+  Expose module `ListStorageType` that was previously hidden in
+  `Capnp.MessageSig.ListStorageType`.
   Stop leaking `Uint32` and `Uint64` in module types. (@jonahbeckford #91)
 
 # v3.6.0

--- a/src/runtime/builderInc.ml
+++ b/src/runtime/builderInc.ml
@@ -34,9 +34,6 @@
    pointer will cause struct storage to be immediately allocated if that pointer
    was null). *)
 
-module Uint32 = Stdint.Uint32
-module Uint64 = Stdint.Uint64
-
 type ro = Message.ro
 type rw = Message.rw
 let invalid_msg = Message.invalid_msg
@@ -307,22 +304,22 @@ module Make (NM : RPC.S) = struct
       numeric lxor default
 
     let get_uint32
-        ~(default : Uint32.t)
+        ~(default : Stdint.Uint32.t)
         (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
-      : Uint32.t =
+      : Stdint.Uint32.t =
       let data = struct_storage.NM.StructStorage.data in
       let numeric = NM.Slice.get_uint32 data byte_ofs in
-      Uint32.logxor numeric default
+      Stdint.Uint32.logxor numeric default
 
     let get_uint64
-        ~(default : Uint64.t)
+        ~(default : Stdint.Uint64.t)
         (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
-      : Uint64.t =
+      : Stdint.Uint64.t =
       let data = struct_storage.NM.StructStorage.data in
       let numeric = NM.Slice.get_uint64 data byte_ofs in
-      Uint64.logxor numeric default
+      Stdint.Uint64.logxor numeric default
 
     let get_float32
         ~(default_bits : int32)
@@ -442,25 +439,25 @@ module Make (NM : RPC.S) = struct
 
     let set_uint32
         ?(discr : Discr.t option)
-        ~(default : Uint32.t)
+        ~(default : Stdint.Uint32.t)
         (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
-        (value : Uint32.t)
+        (value : Stdint.Uint32.t)
       : unit =
       let data = struct_storage.NM.StructStorage.data in
       let () = set_opt_discriminant data discr in
-      NM.Slice.set_uint32 data byte_ofs (Uint32.logxor value default)
+      NM.Slice.set_uint32 data byte_ofs (Stdint.Uint32.logxor value default)
 
     let set_uint64
         ?(discr : Discr.t option)
-        ~(default : Uint64.t)
+        ~(default : Stdint.Uint64.t)
         (struct_storage : (rw, _) NM.StructStorage.t)
         (byte_ofs : int)
-        (value : Uint64.t)
+        (value : Stdint.Uint64.t)
       : unit =
       let data = struct_storage.NM.StructStorage.data in
       let () = set_opt_discriminant data discr in
-      NM.Slice.set_uint64 data byte_ofs (Uint64.logxor value default)
+      NM.Slice.set_uint64 data byte_ofs (Stdint.Uint64.logxor value default)
 
     let set_float32
         ?(discr : Discr.t option)
@@ -666,7 +663,7 @@ module Make (NM : RPC.S) = struct
         ?(default : ro DM.ListStorage.t option)
         (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
-      : (rw, Uint32.t, rw NM.ListStorage.t) InnerArray.t =
+      : (rw, Stdint.Uint32.t, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Bytes4
         ~codecs:uint32_list_codecs struct_storage pointer_word
 
@@ -674,7 +671,7 @@ module Make (NM : RPC.S) = struct
         ?(default : ro DM.ListStorage.t option)
         (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
-      : (rw, Uint64.t, rw NM.ListStorage.t) InnerArray.t =
+      : (rw, Stdint.Uint64.t, rw NM.ListStorage.t) InnerArray.t =
       get_list ?default ~storage_type:ListStorageType.Bytes8
         ~codecs:uint64_list_codecs struct_storage pointer_word
 
@@ -976,8 +973,8 @@ module Make (NM : RPC.S) = struct
         ?(discr : Discr.t option)
         (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
-        (value : ('cap1, Uint32.t, 'cap2 NM.ListStorage.t) InnerArray.t)
-      : (rw, Uint32.t, rw NM.ListStorage.t) InnerArray.t =
+        (value : ('cap1, Stdint.Uint32.t, 'cap2 NM.ListStorage.t) InnerArray.t)
+      : (rw, Stdint.Uint32.t, rw NM.ListStorage.t) InnerArray.t =
       set_list ?discr ~storage_type:ListStorageType.Bytes4 ~codecs:uint32_list_codecs
         struct_storage pointer_word value
 
@@ -985,8 +982,8 @@ module Make (NM : RPC.S) = struct
         ?(discr : Discr.t option)
         (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
-        (value : ('cap1, Uint64.t, 'cap2 NM.ListStorage.t) InnerArray.t)
-      : (rw, Uint64.t, rw NM.ListStorage.t) InnerArray.t =
+        (value : ('cap1, Stdint.Uint64.t, 'cap2 NM.ListStorage.t) InnerArray.t)
+      : (rw, Stdint.Uint64.t, rw NM.ListStorage.t) InnerArray.t =
       set_list ?discr ~storage_type:ListStorageType.Bytes8 ~codecs:uint64_list_codecs
         struct_storage pointer_word value
 
@@ -1238,7 +1235,7 @@ module Make (NM : RPC.S) = struct
         (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
-      : (rw, Uint32.t, rw NM.ListStorage.t) InnerArray.t =
+      : (rw, Stdint.Uint32.t, rw NM.ListStorage.t) InnerArray.t =
       init_list ?discr ~storage_type:ListStorageType.Bytes4 ~codecs:uint32_list_codecs
         struct_storage pointer_word num_elements
 
@@ -1247,7 +1244,7 @@ module Make (NM : RPC.S) = struct
         (struct_storage : (rw, _) NM.StructStorage.t)
         (pointer_word : int)
         (num_elements : int)
-      : (rw, Uint64.t, rw NM.ListStorage.t) InnerArray.t =
+      : (rw, Stdint.Uint64.t, rw NM.ListStorage.t) InnerArray.t =
       init_list ?discr ~storage_type:ListStorageType.Bytes8 ~codecs:uint64_list_codecs
         struct_storage pointer_word num_elements
 

--- a/src/runtime/bytesStorage.ml
+++ b/src/runtime/bytesStorage.ml
@@ -29,9 +29,6 @@
 
 open EndianBytes
 
-module Uint32 = Stdint.Uint32
-module Uint64 = Stdint.Uint64
-
 type t = Bytes.t
 
 let alloc size = Bytes.make size '\x00'
@@ -41,16 +38,16 @@ let length = Bytes.length
 
 let get_uint8      = LittleEndian.get_uint8
 let get_uint16     = LittleEndian.get_uint16
-let get_uint32 s i = Uint32.of_int32 (LittleEndian.get_int32 s i)
-let get_uint64 s i = Uint64.of_int64 (LittleEndian.get_int64 s i)
+let get_uint32 s i = Stdint.Uint32.of_int32 (LittleEndian.get_int32 s i)
+let get_uint64 s i = Stdint.Uint64.of_int64 (LittleEndian.get_int64 s i)
 
 let get_int8  = LittleEndian.get_int8
 let get_int16 = LittleEndian.get_int16
 let get_int32 = LittleEndian.get_int32
 let get_int64 = LittleEndian.get_int64
 
-let set_uint32 s i v = LittleEndian.set_int32 s i (Uint32.to_int32 v)
-let set_uint64 s i v = LittleEndian.set_int64 s i (Uint64.to_int64 v)
+let set_uint32 s i v = LittleEndian.set_int32 s i (Stdint.Uint32.to_int32 v)
+let set_uint64 s i v = LittleEndian.set_int64 s i (Stdint.Uint64.to_int64 v)
 
 let set_int32 = LittleEndian.set_int32
 let set_int64 = LittleEndian.set_int64

--- a/src/runtime/bytesStorage.mli
+++ b/src/runtime/bytesStorage.mli
@@ -1,0 +1,1 @@
+include MessageStorage.S with type t = Bytes.t

--- a/src/runtime/capnp.ml
+++ b/src/runtime/capnp.ml
@@ -27,6 +27,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
+(** [MESSAGE_STORAGE] is the module type of underlying storage used for
+    message segments. *)
+module type MESSAGE_STORAGE = MessageStorage.S
+
 module MessageSig   = MessageSig
 module Message      = Message
 module Array        = CArray

--- a/src/runtime/capnp.ml
+++ b/src/runtime/capnp.ml
@@ -37,6 +37,7 @@ module Array        = CArray
 module BytesStorage = BytesStorage
 module BytesMessage = Message.BytesMessage
 module Codecs       = Codecs
+module ListStorageType = ListStorageType
 module RPC          = RPC
 module Runtime = struct
   module BuilderInc      = BuilderInc

--- a/src/runtime/codecs.ml
+++ b/src/runtime/codecs.ml
@@ -101,7 +101,7 @@ module UncompStream = struct
           in
           let () =
             if segment_count > (max_int / 4) - 2 then
-              Util.out_of_int_range "Uint32.to_int"
+              Util.out_of_int_range "Stdint.Uint32.to_int"
           in
           let segment_count = segment_count + 1 in
           let frame_header_size =

--- a/src/runtime/listStorageType.ml
+++ b/src/runtime/listStorageType.ml
@@ -3,23 +3,13 @@ let sizeof_uint64 = 8
 
 type t =
   | Empty
-  (** list(void), no storage required *)
-
   | Bit
-  (** list(bool), tightly packed bits *)
-
   | Bytes1
   | Bytes2
   | Bytes4
   | Bytes8
-  (** either primitive values or a data-only struct *)
-
   | Pointer
-  (** either a pointer to an external object, or a pointer-only struct *)
-
   | Composite of int * int
-  (** typical struct; parameters are per-element word size for data section
-      and pointers section, respectively *)
 
 let get_byte_count storage_type =
   match storage_type with

--- a/src/runtime/listStorageType.mli
+++ b/src/runtime/listStorageType.mli
@@ -1,0 +1,25 @@
+(** @canonical Capnp.ListStorageType  *)
+
+type t =
+  | Empty
+  (** list(void), no storage required *)
+
+  | Bit
+  (** list(bool), tightly packed bits *)
+
+  | Bytes1
+  | Bytes2
+  | Bytes4
+  | Bytes8
+  (** either primitive values or a data-only struct *)
+
+  | Pointer
+  (** either a pointer to an external object, or a pointer-only struct *)
+
+  | Composite of int * int
+  (** typical struct; parameters are per-element word size for data section
+      and pointers section, respectively *)
+
+val get_byte_count : t -> int
+
+val to_string : t -> string

--- a/src/runtime/message.ml
+++ b/src/runtime/message.ml
@@ -27,8 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
-module Uint32 = Stdint.Uint32
-
 type ro = MessageSig.ro
 type rw = MessageSig.rw
 
@@ -410,7 +408,7 @@ module Make (Storage : MessageStorage.S) = struct
       | None
       | List of 'cap ListStorage.t
       | Struct of ('cap, 'a) StructStorage.t
-      | Capability of Uint32.t
+      | Capability of Stdint.Uint32.t
   end
 
 end [@@inline]

--- a/src/runtime/messageSig.ml
+++ b/src/runtime/messageSig.ml
@@ -27,9 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
-module Uint32 = Stdint.Uint32
-module Uint64 = Stdint.Uint64
-
 type ro
 type rw
 
@@ -72,8 +69,8 @@ module type SEGMENT = sig
 
   val get_uint8  : 'cap t -> int -> int
   val get_uint16 : 'cap t -> int -> int
-  val get_uint32 : 'cap t -> int -> Uint32.t
-  val get_uint64 : 'cap t -> int -> Uint64.t
+  val get_uint32 : 'cap t -> int -> Stdint.Uint32.t
+  val get_uint64 : 'cap t -> int -> Stdint.Uint64.t
 
   (** [get_intXX s ofs] reads a signed integer of the specified width,
       starting at byte offset [ofs] within message segment [s]. *)
@@ -89,8 +86,8 @@ module type SEGMENT = sig
 
   val set_uint8  : rw t -> int -> int -> unit
   val set_uint16 : rw t -> int -> int -> unit
-  val set_uint32 : rw t -> int -> Uint32.t -> unit
-  val set_uint64 : rw t -> int -> Uint64.t -> unit
+  val set_uint32 : rw t -> int -> Stdint.Uint32.t -> unit
+  val set_uint64 : rw t -> int -> Stdint.Uint64.t -> unit
 
   (** [set_intXX s ofs val] writes the value of the width-restricted
       signed integer [val] into read/write-qualified message segment [s],
@@ -241,8 +238,8 @@ module type SLICE = sig
 
   val get_uint8  : 'cap t -> int -> int
   val get_uint16 : 'cap t -> int -> int
-  val get_uint32 : 'cap t -> int -> Uint32.t
-  val get_uint64 : 'cap t -> int -> Uint64.t
+  val get_uint32 : 'cap t -> int -> Stdint.Uint32.t
+  val get_uint64 : 'cap t -> int -> Stdint.Uint64.t
 
   (** [get_intXX s ofs] reads a signed integer of the specified width,
       starting at byte offset [ofs] within the [slice]. *)
@@ -258,8 +255,8 @@ module type SLICE = sig
 
   val set_uint8  : rw t -> int -> int -> unit
   val set_uint16 : rw t -> int -> int -> unit
-  val set_uint32 : rw t -> int -> Uint32.t -> unit
-  val set_uint64 : rw t -> int -> Uint64.t -> unit
+  val set_uint32 : rw t -> int -> Stdint.Uint32.t -> unit
+  val set_uint64 : rw t -> int -> Stdint.Uint64.t -> unit
 
   (** [set_intXX s ofs val] writes the value of the width-restricted
       signed integer [val] into the read/write-qualified [slice],
@@ -335,7 +332,7 @@ module type S = sig
       | None
       | List of 'cap ListStorage.t
       | Struct of ('cap, 'a) StructStorage.t
-      | Capability of Uint32.t
+      | Capability of Stdint.Uint32.t
   end
 end
 

--- a/src/runtime/messageStorage.ml
+++ b/src/runtime/messageStorage.ml
@@ -27,10 +27,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
-module Uint32 = Stdint.Uint32
-module Uint64 = Stdint.Uint64
-
 module type S = sig
+  (** @canonical Capnp.MESSAGE_STORAGE *)
+
   (** [t] is the type of the underlying storage used for message segments. *)
   type t
 
@@ -51,8 +50,8 @@ module type S = sig
 
   val get_uint8  : t -> int -> int
   val get_uint16 : t -> int -> int
-  val get_uint32 : t -> int -> Uint32.t
-  val get_uint64 : t -> int -> Uint64.t
+  val get_uint32 : t -> int -> Stdint.Uint32.t
+  val get_uint64 : t -> int -> Stdint.Uint64.t
 
   (** [get_intXX s ofs] reads a signed integer of the specified width,
       starting at byte offset [ofs] within the message segment. *)
@@ -68,8 +67,8 @@ module type S = sig
 
   val set_uint8  : t -> int -> int -> unit
   val set_uint16 : t -> int -> int -> unit
-  val set_uint32 : t -> int -> Uint32.t -> unit
-  val set_uint64 : t -> int -> Uint64.t -> unit
+  val set_uint32 : t -> int -> Stdint.Uint32.t -> unit
+  val set_uint64 : t -> int -> Stdint.Uint64.t -> unit
 
   (** [set_intXX s ofs val] writes the value of the width-restricted
       signed integer [val] into the message segment, starting at

--- a/src/runtime/otherPointer.ml
+++ b/src/runtime/otherPointer.ml
@@ -27,10 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
-module Uint32 = Stdint.Uint32
-
 type t =
-  | Capability of Uint32.t
+  | Capability of Stdint.Uint32.t
 
 let tag_val_other = 0x3L
 
@@ -45,14 +43,14 @@ let decode (pointer64 : Int64.t) : t =
     let shifted_index = Int64.logand pointer64 index_mask in
     let index64 = Int64.shift_right_logical shifted_index index_shift in
     let index32 = Int64.to_int32 index64 in
-    Capability (Uint32.of_int32 index32)
+    Capability (Stdint.Uint32.of_int32 index32)
   else
     Message.invalid_msg "'other' pointer is of non-capability type"
 
 let encode (descr : t) : Int64.t =
   match descr with
   | Capability index ->
-      let index32 = Uint32.to_int32 index in
+      let index32 = Stdint.Uint32.to_int32 index in
       let index64 = Int64.of_int32 index32 in
       let shifted_index = Int64.shift_left index64 index_shift in
       Int64.logor shifted_index tag_val_other

--- a/src/runtime/rPC.ml
+++ b/src/runtime/rPC.ml
@@ -1,18 +1,15 @@
-module Uint32 = Stdint.Uint32
-module Uint64 = Stdint.Uint64
-
 module Registry : sig
   (** Handy central registry of all known interfaces, for logging. *)
 
   (** Used in the generated code to register the interfaces. *)
-  val register : interface_id:Uint64.t -> name:string -> (int -> string option) -> unit
+  val register : interface_id:Stdint.Uint64.t -> name:string -> (int -> string option) -> unit
 
   (** [pp_method] is a formatter for [(interface_id, method_id)] pairs.
       It prints out qualified names, suitable for logging
       (e.g. "Foo.bar") *)
-  val pp_method : Format.formatter -> Uint64.t * int -> unit
+  val pp_method : Format.formatter -> Stdint.Uint64.t * int -> unit
 
-  val pp_interface : Format.formatter -> Uint64.t -> unit
+  val pp_interface : Format.formatter -> Stdint.Uint64.t -> unit
 end = struct
   type interface = {
     name : string;
@@ -28,7 +25,7 @@ end = struct
     match Hashtbl.find interfaces interface_id with
     | exception Not_found ->
       Format.fprintf f "<interface %a>.<method-%d>"
-        Uint64.printer interface_id
+        Stdint.Uint64.printer interface_id
         method_id
     | interface ->
       match interface.method_lookup method_id with
@@ -39,7 +36,7 @@ end = struct
 
   let pp_interface f interface_id =
     match Hashtbl.find interfaces interface_id with
-    | exception Not_found -> Format.fprintf f "<interface %a>" Uint64.printer interface_id
+    | exception Not_found -> Format.fprintf f "<interface %a>" Stdint.Uint64.printer interface_id
     | interface           -> Format.fprintf f "%s" interface.name
 end
 
@@ -49,19 +46,19 @@ module MethodID : sig
       ['response]. *)
   type ('interface, 'request, 'response) t
 
-  val v : interface_id:Uint64.t -> method_id:int -> ('interface, 'req, 'resp) t
+  val v : interface_id:Stdint.Uint64.t -> method_id:int -> ('interface, 'req, 'resp) t
 
-  val interface_id : (_, _, _) t -> Uint64.t
+  val interface_id : (_, _, _) t -> Stdint.Uint64.t
 
   val method_id : (_, _, _) t -> int
 
   val pp : Format.formatter -> (_, _, _) t -> unit
 end = struct
-  type ('interface, 'request, 'response) t = Uint64.t * int
+  type ('interface, 'request, 'response) t = Stdint.Uint64.t * int
 
   let v ~interface_id ~method_id = (interface_id, method_id)
 
-  let interface_id : (_, _, _) t -> Uint64.t = fst
+  let interface_id : (_, _, _) t -> Stdint.Uint64.t = fst
   let method_id : (_, _, _) t -> int = snd
 
   let pp t = Registry.pp_method t
@@ -112,7 +109,7 @@ module type S = sig
     val capability_field : 'a StructRef.t -> int -> 'b Capability.t
 
     class type generic_service = object
-      method dispatch : interface_id:Uint64.t -> method_id:int -> abstract_method_t
+      method dispatch : interface_id:Stdint.Uint64.t -> method_id:int -> abstract_method_t
       (** Look up a method by ID. The schema compiler generates an implementation of this
           that dispatches to the typed methods of the interface. *)
 
@@ -130,19 +127,19 @@ module type S = sig
     val local : #generic_service -> 'a Capability.t
 
     (** Used in the generated code to get a capability from the attachments by index. *)
-    val get_cap : MessageSig.attachments -> Uint32.t -> 'a Capability.t
+    val get_cap : MessageSig.attachments -> Stdint.Uint32.t -> 'a Capability.t
 
     (** Used in the generated code to store a capability in the attachments. Returns the new index. *)
-    val add_cap : MessageSig.attachments -> 'a Capability.t -> Uint32.t
+    val add_cap : MessageSig.attachments -> 'a Capability.t -> Stdint.Uint32.t
 
     (** Remove a capability from the attachments. Used if the interface is changed. *)
-    val clear_cap : MessageSig.attachments -> Uint32.t -> unit
+    val clear_cap : MessageSig.attachments -> Stdint.Uint32.t -> unit
 
     (** Used to handle calls when the interface ID isn't known. *)
-    val unknown_interface : interface_id:Uint64.t -> abstract_method_t
+    val unknown_interface : interface_id:Stdint.Uint64.t -> abstract_method_t
 
     (** Used to handle calls when the method ID isn't known. *)
-    val unknown_method : interface_id:Uint64.t -> method_id:int -> abstract_method_t
+    val unknown_method : interface_id:Stdint.Uint64.t -> method_id:int -> abstract_method_t
   end
 end
 
@@ -170,7 +167,7 @@ module None (M : MessageSig.S) = struct
     let unknown_method ~interface_id:_ ~method_id:_ _req = failwith "Unknown method"
 
     class type generic_service = object
-      method dispatch : interface_id:Uint64.t -> method_id:int -> abstract_method_t
+      method dispatch : interface_id:Stdint.Uint64.t -> method_id:int -> abstract_method_t
       method release : unit
       method pp : Format.formatter -> unit
     end
@@ -181,7 +178,7 @@ module None (M : MessageSig.S) = struct
   end
 
   module Capability = struct
-    type 'a t = Uint32.t           (* Just the raw CapDescriptor table index. *)
+    type 'a t = Stdint.Uint32.t           (* Just the raw CapDescriptor table index. *)
   end
 
   module Service = struct

--- a/src/runtime/readerInc.ml
+++ b/src/runtime/readerInc.ml
@@ -31,9 +31,6 @@
    here will modify the underlying message; derefencing null pointers and
    reading from truncated structs both lead to default data being returned. *)
 
-module Uint32 = Stdint.Uint32
-module Uint64 = Stdint.Uint64
-
 let sizeof_uint64 = 8
 
 open Message
@@ -298,32 +295,32 @@ module Make (MessageWrapper : RPC.S) = struct
         default
 
   let get_uint32
-      ~(default : Uint32.t)
+      ~(default : Stdint.Uint32.t)
       (struct_storage_opt : ('cap, _) StructStorage.t option)
       (byte_ofs : int)
-    : Uint32.t =
+    : Stdint.Uint32.t =
     match struct_storage_opt with
     | Some struct_storage ->
         let data = struct_storage.StructStorage.data in
         if byte_ofs + 3 < data.Slice.len then
           let numeric = Slice.get_uint32 data byte_ofs in
-          Uint32.logxor numeric default
+          Stdint.Uint32.logxor numeric default
         else
           default
     | None ->
         default
 
   let get_uint64
-      ~(default : Uint64.t)
+      ~(default : Stdint.Uint64.t)
       (struct_storage_opt : ('cap, _) StructStorage.t option)
       (byte_ofs : int)
-    : Uint64.t =
+    : Stdint.Uint64.t =
     match struct_storage_opt with
     | Some struct_storage ->
         let data = struct_storage.StructStorage.data in
         if byte_ofs + 7 < data.Slice.len then
           let numeric = Slice.get_uint64 data byte_ofs in
-          Uint64.logxor numeric default
+          Stdint.Uint64.logxor numeric default
         else
           default
     | None ->
@@ -557,14 +554,14 @@ module Make (MessageWrapper : RPC.S) = struct
       ?(default : ro ListStorage.t option)
       (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
-    : (ro, Uint32.t, 'cap ListStorage.t) InnerArray.t =
+    : (ro, Stdint.Uint32.t, 'cap ListStorage.t) InnerArray.t =
     get_list ?default uint32_list_decoders struct_storage_opt pointer_word
 
   let get_uint64_list
       ?(default : ro ListStorage.t option)
       (struct_storage_opt : ('cap, _) StructStorage.t option)
       (pointer_word : int)
-    : (ro, Uint64.t, 'cap ListStorage.t) InnerArray.t =
+    : (ro, Stdint.Uint64.t, 'cap ListStorage.t) InnerArray.t =
     get_list ?default uint64_list_decoders struct_storage_opt pointer_word
 
   let get_float32_list

--- a/src/runtime/util.ml
+++ b/src/runtime/util.ml
@@ -27,9 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************)
 
-module Uint32 = Stdint.Uint32
-module Uint64 = Stdint.Uint64
-
 exception Out_of_int_range of string
 let out_of_int_range s = raise (Out_of_int_range s)
 
@@ -61,7 +58,7 @@ let encode_signed n num =
 let ceil_ratio num denom = (num + denom - 1) / denom
 
 
-let uint64_equal a b : bool = Uint64.compare a b = 0
+let uint64_equal a b : bool = Stdint.Uint64.compare a b = 0
 
 
 let round_up_mult_8 (x : int) : int =
@@ -116,24 +113,24 @@ let int_of_int64_exn : int64 -> int =
      else
        Int64.to_int i64)
 
-let int_of_uint32_exn : Uint32.t -> int =
+let int_of_uint32_exn : Stdint.Uint32.t -> int =
   if Sys.word_size = 32 then
-    let max_val = Uint32.of_int max_int in
+    let max_val = Stdint.Uint32.of_int max_int in
     (fun u32 ->
-       if Uint32.compare u32 max_val > 0 then
+       if Stdint.Uint32.compare u32 max_val > 0 then
          out_of_int_range "UInt32"
        else
-         Uint32.to_int u32)
+         Stdint.Uint32.to_int u32)
   else
-    Uint32.to_int
+    Stdint.Uint32.to_int
 
-let int_of_uint64_exn : Uint64.t -> int =
-  let max_val = Uint64.of_int max_int in
+let int_of_uint64_exn : Stdint.Uint64.t -> int =
+  let max_val = Stdint.Uint64.of_int max_int in
   (fun u64 ->
-     if Uint64.compare u64 max_val > 0 then
+     if Stdint.Uint64.compare u64 max_val > 0 then
        out_of_int_range "UInt64"
      else
-       Uint64.to_int u64)
+       Stdint.Uint64.to_int u64)
 
 let int32_of_int_exn : int -> int32 =
   if Sys.word_size = 64 then
@@ -147,22 +144,22 @@ let int32_of_int_exn : int -> int32 =
   else
     Int32.of_int
 
-let uint32_of_int_exn : int -> Uint32.t =
+let uint32_of_int_exn : int -> Stdint.Uint32.t =
   if Sys.word_size = 64 then
-    let max_val = Uint32.to_int (Uint32.max_int) in
+    let max_val = Stdint.Uint32.to_int (Stdint.Uint32.max_int) in
     (fun i ->
        if i < 0 || i > max_val then
-         invalid_arg "Uint32.of_int"
+         invalid_arg "Stdint.Uint32.of_int"
        else
-         Uint32.of_int i)
+         Stdint.Uint32.of_int i)
   else
-    Uint32.of_int
+    Stdint.Uint32.of_int
 
 let uint64_of_int_exn i =
   if i < 0 then
-    invalid_arg "Uint64.of_int"
+    invalid_arg "Stdint.Uint64.of_int"
   else
-    Uint64.of_int i
+    Stdint.Uint64.of_int i
 
 
 let hex_table = [|


### PR DESCRIPTION
Three hygiene changes:

- Expose module type `MESSAGE_STORAGE` which was used as a `Capnp.Message.Make`
  functor parameter but was previously hidden in `Capnp__MessageStorage.S`. (I say "hidden" because `MessageStorage` is not being exported by the `capnp.ml` wrapper, so a user has to hack into Dune internals to get access to the `S` module type.)
- Stop leaking `Uint32` and `Uint64` in module types.
- Expose `ListStorageType`. The `Capnp.MessageSig.S` is public (aka. part of wrapped capnp.ml) and has a ListStorage module. But ListStorage.t has a storage_type field of type `Capnp.MessageSig.ListStorageType.t` that was not public.

The first one is important since my MlFront analysis tool has a security posture that does not allow external access to double underscore (private) modules.

The second one is part of a broader issue that there are few `.mli` files in `capnp-ocaml`. That means unnecessary modules, types and values leak. This PR only addresses the one leak that is very visible to me.

The third one is similar to the first one.