### PR TITLE
Get dune build working on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+# PENDING
+
+Build system:
+
+- `CAPNP_INCLUDE` environment variable can be set if the build machine does
+  not have a standard location to store `capnp/*.capnp` schema file (ex.
+  `/usr/include` on Unix) (@jonahbeckford #92)
+- Windows compiler flags and commands are detected and used in benchmarks
+  (@jonahbeckford #92)
+
 # v3.6.0
 
 - Update README to talk about stdint, not uint (reported by @liyishuai).  

--- a/README.adoc
+++ b/README.adoc
@@ -563,11 +563,17 @@ capnp-ocaml requires OCaml >= 4.02.
 You should be able to install capnp-ocaml with
 http://opam.ocaml.org[OPAM] using using `opam install capnp`.
 
-If you prefer to compile manually, you will need jbuilder, Findlib, and OCaml
+If you prefer to compile manually, you will need Dune, Findlib, and OCaml
 packages `core_kernel`, `extunix`, `uint`, `ocplib-endian`, and `res`.
-Run `jbuilder build` to build both the compiler and the runtime library,
-and then use `jbuilder install` to copy them into appropriate places within your
+Run `dune build` to build both the compiler and the runtime library,
+and then use `opam install` or `dune install` to copy them into appropriate places within your
 filesystem.
+
+Compiling manually on Windows can be done if you create an opam 2.2 switch or DkML switch,
+and download and extract the [Cap’n Proto Win32 zip](https://capnproto.org/install.html#installation-windows).
+Use a PowerShell command like the following for development, replacing *YOU* with your username and
+*1.0.2* with the capnp version you downloaded:
+`opam exec -- env CAPNP_INCLUDE='C:\Users\YOU\Downloads\capnproto-c++-win32-1.0.2\capnproto-c++-1.0.2\src' sh -c "PATH=`"`$(cygpath 'C:\Users\YOU\Downloads\capnproto-c++-win32-1.0.2\capnproto-tools-win32-1.0.2'):`$PATH`" dune build"`
 
 Contact
 -------

--- a/src/benchmark/dune
+++ b/src/benchmark/dune
@@ -2,44 +2,64 @@
  (name main)
  (enabled_if (= %{architecture} amd64))
  (libraries capnp capnp_unix fast_rand base)
- (ocamlopt_flags :standard -O3 -inline 2000))
+ (ocamlopt_flags :standard (:include fastRand/foreign_stubs_flags.sexp) -inline 2000))
 
 (rule
- (targets carsales)
+ (enabled_if (= %{os_type} "Unix"))
+ (target ln.lines)
+ (action (with-stdout-to %{target} (echo "ln"))))
+
+(rule
+ (enabled_if (= %{os_type} "Win32"))
+ (target ln.lines)
+ (action (with-stdout-to %{target} (echo "cmd\n/c\ncopy"))))
+
+(rule
+ (targets carsales%{ext_exe})
  (enabled_if (= %{architecture} amd64))
  (deps main.exe)
  (action
-  (run ln main.exe %{targets})))
+  (run %{read-lines:ln.lines} main.exe %{targets})))
 
 (rule
- (targets catrank)
+ (targets catrank%{ext_exe})
  (enabled_if (= %{architecture} amd64))
  (deps main.exe)
  (action
-  (run ln main.exe %{targets})))
+  (run %{read-lines:ln.lines} main.exe %{targets})))
 
 (rule
- (targets eval)
+ (targets eval%{ext_exe})
  (enabled_if (= %{architecture} amd64))
  (deps main.exe)
  (action
-  (run ln main.exe %{targets})))
+  (run %{read-lines:ln.lines} main.exe %{targets})))
+
+(rule
+ (enabled_if (<> %{env:CAPNP_INCLUDE=} ""))
+ (target capnp_compile_args.lines)
+ (action (with-stdout-to %{target} (echo "-I\n%{env:CAPNP_INCLUDE=}\n"))))
+
+(rule
+ (enabled_if (= %{env:CAPNP_INCLUDE=} ""))
+ (target capnp_compile_args.lines)
+ (action (with-stdout-to %{target} (echo ""))))
 
 (rule
  (targets carsales.ml carsales.mli)
  (action
-  (run capnp compile -o %{bin:capnpc-ocaml} %{dep:carsales.capnp})))
+  (run capnp compile -o %{bin:capnpc-ocaml} %{read-lines:capnp_compile_args.lines} %{dep:carsales.capnp})))
 
 (rule
  (targets catrank.ml catrank.mli)
  (action
-  (run capnp compile -o %{bin:capnpc-ocaml} %{dep:catrank.capnp})))
+  (run capnp compile -o %{bin:capnpc-ocaml} %{read-lines:capnp_compile_args.lines} %{dep:catrank.capnp})))
 
 (rule
  (targets eval.ml eval.mli)
  (action
-  (run capnp compile -o %{bin:capnpc-ocaml} %{dep:eval.capnp})))
+  (run capnp compile -o %{bin:capnpc-ocaml} %{read-lines:capnp_compile_args.lines} %{dep:eval.capnp})))
 
 (alias
  (name benchmarks)
- (deps carsales catrank eval))
+ (deps carsales%{ext_exe} catrank%{ext_exe} eval%{ext_exe}))

--- a/src/benchmark/fastRand/dune
+++ b/src/benchmark/fastRand/dune
@@ -1,9 +1,19 @@
+(rule
+ (enabled_if (= %{os_type} "Unix"))
+ (target foreign_stubs_flags.sexp)
+ (action (with-stdout-to %{target} (echo "(-O3)"))))
+
+(rule
+ (enabled_if (= %{os_type} "Win32"))
+ (target foreign_stubs_flags.sexp)
+ (action (with-stdout-to %{target} (echo "(-O2)"))))
+
 (library
  (enabled_if (= %{architecture} amd64))
  (foreign_stubs
   (language c)
   (names fast_rand)
-  (flags :standard -O3))
+  (flags :standard (:include foreign_stubs_flags.sexp)))
  (name fast_rand)
  (wrapped false)
  (flags :standard -w -3))


### PR DESCRIPTION
During capnp-ocaml development I want `dune build` to work. That compiles the whole project, including the benchmark code. `dune build` makes it easy to see if I'm breaking other code, even if I can't run the benchmarks (yet) on Windows.

Two changes:

- `CAPNP_INCLUDE` environment variable can be set if the build machine does not have a standard location to store `capnp/*.capnp` schema file (ex. `/usr/include` on Unix)
- Windows compiler flags and commands are detected and used in benchmarks

I also added in manual compile instructions for Windows.

The python benchmark tool was not modified. Running the benchmark on Unix is fine for now.